### PR TITLE
scroll modals on small height window

### DIFF
--- a/packages/app/src/components/account/AccountModal.tsx
+++ b/packages/app/src/components/account/AccountModal.tsx
@@ -27,8 +27,13 @@ export const AccountModal: FC<AccountModalProps> = ({ showModal, setShowModal })
   return (
     <>
       {account && chainId && showModal && (
-        <Layer animation="fadeIn" onEsc={() => setShowModal(false)} onClickOutside={() => setShowModal(false)}>
-          <Card>
+        <Layer
+          style={{ overflow: "scroll" }}
+          animation="fadeIn"
+          onEsc={() => setShowModal(false)}
+          onClickOutside={() => setShowModal(false)}
+        >
+          <Card flex={false}>
             <Box pad="medium" gap="medium">
               <CardHeader>
                 <Text size="xlarge">Account info</Text>

--- a/packages/app/src/components/farm/farm.tsx
+++ b/packages/app/src/components/farm/farm.tsx
@@ -61,8 +61,8 @@ const Farm: FC<Props> = ({ name, symbol, tokenBalance }) => {
     <>
       <Button primary onClick={handleShow} label="Farm" />
       {show && (
-        <Layer animation="fadeIn" onEsc={handleClose} onClickOutside={handleClose}>
-          <Card pad="medium" width="large">
+        <Layer style={{ overflow: "scroll" }} animation="fadeIn" onEsc={handleClose} onClickOutside={handleClose}>
+          <Card flex={false} pad="medium" width="large">
             <CardHeader justify="center" pad={{ bottom: "small" }}>{`Farm ${symbol}`}</CardHeader>
             <CardBody>
               <Form>

--- a/packages/app/src/components/farm/harvest.tsx
+++ b/packages/app/src/components/farm/harvest.tsx
@@ -45,8 +45,13 @@ const Harvest: FC<Props> = ({ name, symbol, availableRewards }) => {
         style={{ color: "#4E66DE" }}
       />
       {show && (
-        <Layer animation="fadeIn" onEsc={() => setShow(false)} onClickOutside={() => setShow(false)}>
-          <Card pad="medium" width="large">
+        <Layer
+          style={{ overflow: "scroll" }}
+          animation="fadeIn"
+          onEsc={() => setShow(false)}
+          onClickOutside={() => setShow(false)}
+        >
+          <Card flex={false} pad="medium" width="large">
             <CardHeader justify="center" pad={{ bottom: "small" }}>{`Harvest ${symbol}`}</CardHeader>
             <CardBody align="center">
               <Text className="balance">

--- a/packages/app/src/components/farm/unfarm.tsx
+++ b/packages/app/src/components/farm/unfarm.tsx
@@ -59,8 +59,13 @@ const Unfarm: FC<Props> = ({ name, symbol, stake }) => {
     <>
       <Button fill="horizontal" primary onClick={handleShow} label="Unfarm" />
       {show && (
-        <Layer animation="fadeIn" onEsc={() => setShow(false)} onClickOutside={() => setShow(false)}>
-          <Card pad="medium" width="large">
+        <Layer
+          style={{ overflow: "scroll" }}
+          animation="fadeIn"
+          onEsc={() => setShow(false)}
+          onClickOutside={() => setShow(false)}
+        >
+          <Card flex={false} pad="medium" width="large">
             <CardHeader justify="center" pad={{ bottom: "small" }}>{`Unfarm ${symbol}`}</CardHeader>
             <CardBody>
               <Form>

--- a/packages/app/src/components/faucet/index.tsx
+++ b/packages/app/src/components/faucet/index.tsx
@@ -22,8 +22,8 @@ const Faucet: FC<props> = ({ symbol }) => {
     <>
       <Button plain onClick={handleShow} label="Faucet" />
       {show && (
-        <Layer animation="fadeIn" onEsc={handleClose} onClickOutside={handleClose}>
-          <Card pad="medium" height="medium" width="medium">
+        <Layer style={{ overflow: "scroll" }} animation="fadeIn" onEsc={handleClose} onClickOutside={handleClose}>
+          <Card flex={false} pad="medium" height="medium" width="medium">
             <CardHeader>
               <Heading>{symbol} Faucet</Heading>
             </CardHeader>

--- a/packages/app/src/components/swap/ConfirmSwapModal.tsx
+++ b/packages/app/src/components/swap/ConfirmSwapModal.tsx
@@ -78,13 +78,14 @@ const ConfirmSwapModal: FC<Props> = ({
     <>
       {show && (
         <Layer
+          style={{ overflow: "scroll" }}
           animation="fadeIn"
           onEsc={() => {
             confirmStatus !== "Submitted" && onDismiss();
           }}
           onClickOutside={() => confirmStatus !== "Submitted" && onDismiss()}
         >
-          <Card pad="medium">
+          <Card flex={false} pad="medium">
             <CardHeader
               justify="center"
               pad={{ bottom: "small" }}

--- a/packages/app/src/components/swap/exit.tsx
+++ b/packages/app/src/components/swap/exit.tsx
@@ -152,13 +152,14 @@ const ExitPool: FC<Props> = ({
 
       {show && (
         <Layer
+          style={{ overflow: "scroll" }}
           animation="fadeIn"
           margin={{ top: "xlarge" }}
           position="top"
           onEsc={handleClose}
           onClickOutside={handleClose}
         >
-          <Card pad="medium" width="large">
+          <Card flex={false} pad="medium" width="large">
             <CardHeader justify="center" pad={{ bottom: "small" }}>{`Exit tender${symbol}/${symbol}`}</CardHeader>
             <CardBody>
               <Tabs id="exit-type" activeIndex={tabIndex} onActive={onActive}>

--- a/packages/app/src/components/swap/join.tsx
+++ b/packages/app/src/components/swap/join.tsx
@@ -228,13 +228,14 @@ const JoinPool: FC<Props> = ({
       <Button primary onClick={handleShow} label="Join Pool" />
       {show && (
         <Layer
+          style={{ overflow: "scroll" }}
           animation="fadeIn"
           margin={{ top: "xlarge" }}
           position="top"
           onEsc={handleClose}
           onClickOutside={handleClose}
         >
-          <Card pad="medium" width="large">
+          <Card flex={false} pad="medium" width="large">
             <CardHeader justify="center" pad={{ bottom: "small" }}>{`Join tender${symbol}/${symbol}`}</CardHeader>
             <CardBody>
               <Tabs id="join-type" activeIndex={tabIndex} onActive={onActive}>


### PR DESCRIPTION
When content did not fit, the modals' content was causing children to overlap.