### PR TITLE
Mv/fix add liquidity

### DIFF
--- a/packages/app/src/components/swap/exit.tsx
+++ b/packages/app/src/components/swap/exit.tsx
@@ -113,7 +113,7 @@ const ExitPool: FC<Props> = ({
     const tokenInBN = utils.parseEther(lpSharesInput || "0");
     // return tokenInBN.mul(utils.parseEther("1")).div(tokenLpBalance).mul(lpShares).div(utils.parseEther("1"))
     const total = hasValue(lpShares) ? lpShares : "1";
-    return tokenInBN.mul(balance).div(total);
+    return tokenInBN.mul(balance).div(total).sub(1000);
   };
 
   const removeLiquidity = async (e: any) => {

--- a/packages/app/src/components/swap/join.tsx
+++ b/packages/app/src/components/swap/join.tsx
@@ -188,7 +188,7 @@ const JoinPool: FC<Props> = ({
   const calcPoolOutFromRatio = () => {
     const tokenInBN = utils.parseEther(tokenInput);
     // return tokenInBN.mul(utils.parseEther("1")).div(tokenLpBalance).mul(lpShares).div(utils.parseEther("1"))
-    return tokenInBN.mul(lpShares).div(tokenLpBalance);
+    return tokenInBN.mul(lpShares).div(tenderLpBalance);
   };
 
   const addLiquidity: MouseEventHandler<HTMLButtonElement> = async (e) => {

--- a/packages/app/src/components/swap/join.tsx
+++ b/packages/app/src/components/swap/join.tsx
@@ -187,8 +187,9 @@ const JoinPool: FC<Props> = ({
 
   const calcPoolOutFromRatio = () => {
     const tokenInBN = utils.parseEther(tokenInput);
-    // return tokenInBN.mul(utils.parseEther("1")).div(tokenLpBalance).mul(lpShares).div(utils.parseEther("1"))
-    return tokenInBN.mul(lpShares).div(tenderLpBalance);
+    const lpSharesBN = utils.parseEther(lpShares.toString());
+    const tokenLpBalanceBN = utils.parseEther(tokenLpBalance.toString());
+    return tokenInBN.mul(lpSharesBN.sub(1)).div(tokenLpBalanceBN.add(1));
   };
 
   const addLiquidity: MouseEventHandler<HTMLButtonElement> = async (e) => {

--- a/packages/app/src/components/swap/join.tsx
+++ b/packages/app/src/components/swap/join.tsx
@@ -187,9 +187,10 @@ const JoinPool: FC<Props> = ({
 
   const calcPoolOutFromRatio = () => {
     const tokenInBN = utils.parseEther(tokenInput);
-    const lpSharesBN = utils.parseEther(lpShares.toString());
-    const tokenLpBalanceBN = utils.parseEther(tokenLpBalance.toString());
-    return tokenInBN.mul(lpSharesBN.sub(1)).div(tokenLpBalanceBN.add(1));
+    const lpSharesBN = BigNumber.from(lpShares)
+    const tokenLpBalanceBN = BigNumber.from(tokenLpBalance)
+
+    return tokenInBN.mul(lpSharesBN.sub(1)).div(tokenLpBalanceBN.add(1)).sub(1000)
   };
 
   const addLiquidity: MouseEventHandler<HTMLButtonElement> = async (e) => {


### PR DESCRIPTION
- fixed displaying the correct ApproveToken elements (changed the prop to `show`, easier to reason about it than about a semantically negated value)
- fixed add liquidity functionality, rounding error did not let it go through
