### PR TITLE
app: fix apy to include 0 days

### DIFF
--- a/packages/app/src/components/featured-card/index.tsx
+++ b/packages/app/src/components/featured-card/index.tsx
@@ -21,13 +21,12 @@ const FeaturedCards: FC = () => {
       const dpyData = Array.from(data.tenderizerDays)
         .filter((item) => item.id.toLowerCase().includes(stakers[key].name))
         .slice(0, -1)
-        .filter((item) => item.DPY !== "0");
+        // .filter((item) => item.DPY !== "0");
       const sumDPYInPoints = dpyData.reduce((seedValue, item) => seedValue + parseFloat(item.DPY), 0);
 
-      if (sumDPYInPoints !== 0) {
-        const yearlyAvarageRate = (sumDPYInPoints / dpyData.length) * 365;
-        apyInPoints = Math.pow(1 + yearlyAvarageRate / 365, 365) - 1;
-      }
+      const yearlyAvarageRate = (sumDPYInPoints / dpyData.length) * 365;
+      apyInPoints = Math.pow(1 + yearlyAvarageRate / 365, 365) - 1;
+      
     }
     const apy = (apyInPoints * 100).toFixed(2);
     cards.push(<TokenCard key={key} info={stakers[key]} url={key} apy={apy} />);

--- a/packages/app/src/components/featured-card/index.tsx
+++ b/packages/app/src/components/featured-card/index.tsx
@@ -21,10 +21,14 @@ const FeaturedCards: FC = () => {
       const dpyData = Array.from(data.tenderizerDays)
         .filter((item) => item.id.toLowerCase().includes(stakers[key].name))
         .slice(0, -1)
-        // .filter((item) => item.DPY !== "0");
+
+      const dayStart = parseInt(dpyData[0].id.split("_")[0])
+      const dayEnd = parseInt(dpyData[dpyData.length - 1].id.split("_")[0])
+      const daysElapsed = dayEnd - dayStart + 1
+
       const sumDPYInPoints = dpyData.reduce((seedValue, item) => seedValue + parseFloat(item.DPY), 0);
 
-      const yearlyAvarageRate = (sumDPYInPoints / dpyData.length) * 365;
+      const yearlyAvarageRate = (sumDPYInPoints / daysElapsed ) * 365;
       apyInPoints = Math.pow(1 + yearlyAvarageRate / 365, 365) - 1;
       
     }

--- a/packages/app/src/components/token-card/index.tsx
+++ b/packages/app/src/components/token-card/index.tsx
@@ -24,26 +24,19 @@ const TokenCard: FC<Props> = (props) => {
   const logo = require("../../images/" + info.bwTenderLogo);
 
   return (
-    <Box pad="large" style={{ flex: "1" }}>
+    <Box pad="large" gap="small" style={{ flex: "1" }}>
       <Box align="center" margin={{ vertical: "small" }}>
         <Image src={logo.default} sizes="large" />
         <Text size="xlarge">{info.title}</Text>
       </Box>
-      <Box pad={{ horizontal: "large" }} gap="medium">
-        <Box direction="column" align="center">
-          <Text size="medium" color="light-3">
-            Stake
-          </Text>
-          <Box direction="row" align="center" gap="small">
-            <Text size="large" weight="bold">
-              {apy}
+          <Box direction="column" align="center" gap="small">
+          <Text size="medium" weight="normal" color="light-3">
+              APY
             </Text>
-            <Text size="small" weight="normal" color="light-3">
-              % APY
+            <Text size="large" weight="bold">
+              {apy} <Text size="medium">%</Text>
             </Text>
           </Box>
-        </Box>
-      </Box>
     </Box>
   );
 };


### PR DESCRIPTION
Include 0 days in the calculation 

> e.g. imagine staking rewards are only earned once a week
then only 1 day will have a non-zero value per week, but to get the correct annual value you will still need to count the other 0 values for the week to get what the average per day is over that week.

Also Fixes #108 