### PR TITLE
display modal to switch to rinkeby

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -32,7 +32,7 @@
     "react-scripts": "4.0.3",
     "rimble-ui": "^0.14.0",
     "styled-components": "^5.3.0",
-    "typescript": "^4.1.2",
+    "typescript": "^4.4.3",
     "web-vitals": "^1.0.1"
   },
   "scripts": {

--- a/packages/app/src/components/actions/deposit.tsx
+++ b/packages/app/src/components/actions/deposit.tsx
@@ -85,7 +85,6 @@ const Deposit: FC<Props> = ({ name, symbol, logo, tokenBalance, tenderTokenBalan
           </Box>
         </Box>
       </Box>
-
       <Box direction="row" justify="center" align="center">
         <Form validate="change">
           <Box align="center" justify="center">

--- a/packages/app/src/components/approve/ApproveToken.tsx
+++ b/packages/app/src/components/approve/ApproveToken.tsx
@@ -1,8 +1,9 @@
-import { FC, MouseEventHandler } from "react";
+import { FC } from "react";
 import { constants, Contract } from "ethers";
 import { Box, Button, Tip, Text } from "grommet";
 import { LoadingButtonContent } from "../LoadingButtonContent";
 import { useContractFunction } from "../../utils/useDappPatch";
+import { useForceRinkebyFunction } from "../../utils/forceChainIdOnCall";
 
 type Props = {
   symbol: string;
@@ -16,56 +17,64 @@ const ApproveToken: FC<Props> = ({ symbol, spender, show, token }) => {
     transactionName: `Approve ${symbol}`,
   });
 
-  const handleApproval: MouseEventHandler<HTMLButtonElement> = async (e) => {
+  const {
+    rinkebyForcedFunction: handleApproval,
+    renderError,
+  } = useForceRinkebyFunction(async (e) => {
     e.preventDefault();
 
     if (show) {
       await approveToken(spender, constants.MaxUint256);
     }
-  };
+  });
 
   if (!show) {
     return <></>;
   }
 
   return (
-    <Button
-      secondary
-      gap="medium"
-      fill="horizontal"
-      onClick={handleApproval}
-      disabled={approveTx.status !== "None" && approveTx.status !== "Success" && approveTx.status !== "Exception"}
-      label={
-        <>
-          <Box justify="center" align="center" direction="row" gap="small" pad={{ horizontal: "xsmall" }}>
-            {approveTx.status === "Mining" && <LoadingButtonContent />}
-            <Text weight="normal">Allow Tenderize to spend {symbol}</Text>
-            <Tip
-              plain
-              dropProps={{
-                round: {
-                  size: "20px",
-                },
-                background: "rgba(0,0,0,0.4)",
-                elevation: "none",
-              }}
-              content={
-                <Box width="medium" elevation="none" pad="medium">
-                  <Text color="white">
-                    You must give the Tenderize smart contracts permission to use your {symbol}. You only have to do
-                    this once per token.
-                  </Text>
-                </Box>
-              }
-            >
-              <span style={{ border: "1px solid white", borderRadius: "50%", paddingLeft: "5px", paddingRight: "5px" }}>
-                &#8505;
-              </span>
-            </Tip>
-          </Box>
-        </>
-      }
-    />
+    <>
+      <Button
+        secondary
+        gap="medium"
+        fill="horizontal"
+        onClick={handleApproval}
+        disabled={approveTx.status !== "None" && approveTx.status !== "Success" && approveTx.status !== "Exception"}
+        label={
+          <>
+            <Box justify="center" align="center" direction="row" gap="small" pad={{ horizontal: "xsmall" }}>
+              {approveTx.status === "Mining" && <LoadingButtonContent />}
+              <Text weight="normal">Allow Tenderize to spend {symbol}</Text>
+              <Tip
+                plain
+                dropProps={{
+                  round: {
+                    size: "20px",
+                  },
+                  background: "rgba(0,0,0,0.4)",
+                  elevation: "none",
+                }}
+                content={
+                  <Box width="medium" elevation="none" pad="medium">
+                    <Text color="white">
+                      You must give the Tenderize smart contracts permission to use your {symbol}. You only have to do
+                      this once per token.
+                    </Text>
+                  </Box>
+                }
+              >
+                <span
+                  style={{ border: "1px solid white", borderRadius: "50%", paddingLeft: "5px", paddingRight: "5px" }}
+                >
+                  &#8505;
+                </span>
+              </Tip>
+            </Box>
+          </>
+        }
+      />
+      {renderError()}
+    </>
   );
 };
 

--- a/packages/app/src/utils/forceChainIdOnCall.tsx
+++ b/packages/app/src/utils/forceChainIdOnCall.tsx
@@ -1,0 +1,49 @@
+import { ReactElement, useCallback, useState } from "react";
+import { ChainId, useEthers } from "@usedapp/core";
+import { Box, Button, Card, CardFooter, CardHeader, Layer } from "grommet";
+
+type InferArguments<T> = T extends (...t: [...infer Arg]) => any ? Arg : never;
+type InferReturn<T> = Promise<T extends (...t: [...infer Res]) => infer Res ? Res : never>;
+
+export const useForceRinkebyFunction = <TFunc extends (...args: any[]) => any>(
+  func: TFunc
+): {
+  rinkebyForcedFunction: (...args: InferArguments<TFunc>) => InferReturn<TFunc>;
+  renderError: () => ReactElement;
+} => {
+  const { chainId } = useEthers();
+  const [wrongNetwork, setWrongNetwork] = useState(false);
+  const onClose = useCallback((e) => {
+    e.preventDefault();
+    setWrongNetwork(false);
+  }, []);
+
+  const renderError = () => {
+    if (wrongNetwork === false) return <></>;
+    return (
+      <Layer style={{ overflow: "auto" }} animation="fadeIn" onEsc={onClose} onClickOutside={onClose}>
+        <Card flex={false} pad="medium" width="large">
+          <CardHeader justify="center" pad={{ bottom: "small" }}>
+            {"Please switch to rinkeby to use Tenderize"}
+          </CardHeader>
+          <CardFooter align="center" justify="center" pad={{ top: "medium" }}>
+            <Box justify="center" gap="small">
+              <Button primary onClick={onClose} label={"OK"} />
+            </Box>
+          </CardFooter>
+        </Card>
+      </Layer>
+    );
+  };
+
+  return {
+    rinkebyForcedFunction: async (...args: InferArguments<TFunc>) => {
+      if (chainId === ChainId.Rinkeby) {
+        return await func(...args);
+      } else {
+        setWrongNetwork(true);
+      }
+    },
+    renderError,
+  };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -16108,10 +16108,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.1.2:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
-  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+typescript@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.3.tgz#bdc5407caa2b109efd4f82fe130656f977a29324"
+  integrity sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==
 
 typy@^3.3.0:
   version "3.3.0"


### PR DESCRIPTION
fixes #110 

If the account is not on rinkeby, approval buttons should be displayed everywhere before all actions. Approve token is now wrapped in a function which won't execute if it the network is not rinkeby.