### PR TITLE
subgraph: remove controller and esp/bpool notions

### DIFF
--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -9,18 +9,14 @@ type TenderizeGlobal @entity { # Global Values/ TODO: better name?
 type Config @entity{
   "Name of the protocol eg. 'livepeer'"
   id: ID!
-  "Address of the Controller"
-  controller: String!
   "Address of the ERC20 token for integration"
   steak: String!
   "Address of Tenderizer"
   tenderizer: String!
   "Address of ERC20 Tender Token"
   tenderToken: String!
-  "Address of Elastic Supply Pool"
-  esp: String!
-  "Address of liquidity pool for pair"
-  bpool: String!
+  "Address of the TenderSwap pool for this Tenderizerr"
+  tenderSwap: String!
   "Address of TenderFarm contract"
   tenderFarm: String!
 }
@@ -178,12 +174,10 @@ type UserDeploymentDay @entity {
 type TenderizerCreatedEvent @entity {
   id: ID!
   name: String!
-  controller: String!
   steak: String!
   tenderizer: String!
   tenderToken: String!
-  esp: String!
-  bpool: String!
+  tenderSwap: String!
   tenderFarm: String!
   timestamp: BigInt!
 }

--- a/packages/subgraph/src/mappings/registry.ts
+++ b/packages/subgraph/src/mappings/registry.ts
@@ -22,12 +22,10 @@ export function handleTenderizerCreated(config: TenderizerCreated): void {
   let protocolConfigEvent = new TenderizerCreatedEvent(config.transaction.hash.toHex())
   
   protocolConfigEvent.name = params.name
-  protocolConfigEvent.controller = protocolConfig.controller = params.controller.toHex()
   protocolConfigEvent.steak = protocolConfig.steak = params.steak.toHex()
   protocolConfigEvent.tenderizer = protocolConfig.tenderizer = params.tenderizer.toHex()
   protocolConfigEvent.tenderToken = protocolConfig.tenderToken = params.tenderToken.toHex()
-  protocolConfigEvent.esp = protocolConfig.esp = params.esp.toHex()
-  protocolConfigEvent.bpool = protocolConfig.bpool = params.bpool.toHex()
+  protocolConfigEvent.tenderSwap = protocolConfig.tenderSwap = params.tenderSwap.toHex()
   protocolConfigEvent.tenderFarm = protocolConfig.tenderFarm = params.tenderFarm.toHex()
   protocolConfigEvent.timestamp = config.block.timestamp
   

--- a/packages/subgraph/src/mappings/utils.ts
+++ b/packages/subgraph/src/mappings/utils.ts
@@ -252,11 +252,13 @@ export function getUSDPrice(protocol: string): BigDecimal {
 
 export function LPTokenToToken(amount: BigDecimal, protocol: string): BigDecimal {
   let config = Config.load(protocol)
-  let bPool = BPool.bind(Address.fromString(config.bpool))
-  let esp = ElasticSupplyPool.bind(Address.fromString(config.esp))
-  let totalSupply = esp.totalSupply().toBigDecimal()
-  let steakTokens = bPool.getBalance(Address.fromString(config.steak)).toBigDecimal()
-  let tenderTokens = bPool.getBalance(Address.fromString(config.tenderToken)).toBigDecimal()
+  let tenderSwap = TenderSwap.bind(Address.fromString(config.tenderSwap))
+  const tenderSwapAddr = tenderSwap.liquidityPoolToken()
+  let lpToken = LiquidityPoolToken.bind(Address.fromString(tenderSwapAddr))
+  let totalSupply = lpToken.totalSupply().toBigDecimal()
+  let tenderTokens = tenderSwap.getToken0Balance().toBigDecimal()
+  let steakTokens = tenderSwap.getToken1Balance().toBigDecimal()
+  
   return amount.div(totalSupply).times(steakTokens.plus(tenderTokens))
 }
 
@@ -269,8 +271,7 @@ export function tokensToShares(amount: BigInt, protocol: string): BigInt {
 export function addressIsContract(config: Config, address: Address): Boolean {
   let addressString = address.toHex()
   return (
-  addressString.includes(config.esp) ||
-  addressString.includes(config.bpool) ||
+  addressString.includes(config.tenderSwap) ||
   addressString.includes(config.tenderFarm) ||
   addressString.includes(config.tenderizer)
   ) as Boolean


### PR DESCRIPTION
Removes `Controller` usage and  `ElasticSupplyPool` and `BPool` usage for `TenderSwap` 