### PR TITLE
Add missing notification to faucet

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -24,7 +24,7 @@
     "@types/node": "^12.0.0",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
-    "@usedapp/core": "^0.7.1",
+    "@usedapp/core": "^0.9.1",
     "@web3-react/fortmatic-connector": "^6.1.6",
     "@web3-react/portis-connector": "^6.1.9",
     "@web3-react/walletconnect-connector": "^6.2.4",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -29,6 +29,7 @@
     "@web3-react/portis-connector": "^6.1.9",
     "@web3-react/walletconnect-connector": "^6.2.4",
     "@web3-react/walletlink-connector": "^6.2.3",
+    "bufferutil": "^4.0.6",
     "ethers": "^5.5.2",
     "framer-motion": "^4.1.17",
     "grommet": "^2.19.1",
@@ -43,6 +44,7 @@
     "styled-components": "^5.3.3",
     "swr": "^1.0.1",
     "typescript": "^4.4.3",
+    "utf-8-validate": "^5.0.8",
     "web-vitals": "^1.0.1"
   },
   "eslintConfig": {

--- a/packages/app/src/components/actions/deposit.tsx
+++ b/packages/app/src/components/actions/deposit.tsx
@@ -4,14 +4,15 @@ import { useEthers, useContractFunction } from "@usedapp/core";
 import { BigNumber, BigNumberish, utils, constants } from "ethers";
 import { Button, Box, Form, FormField, Image, Text, TextInput } from "grommet";
 import { useQuery } from "@apollo/client";
-import ApproveToken from "../approve/ApproveToken";
-import { useIsTokenApproved } from "../approve/useIsTokenApproved";
+import ApproveToken from "components/approve/ApproveToken";
+import { useIsTokenApproved } from "components/approve/useIsTokenApproved";
 import { InfoCard, Queries } from "@tender/shared/src/index";
-import { weiToEthWithDecimals } from "../../utils/amountFormat";
-import { AmountInputFooter } from "../AmountInputFooter";
-import { LoadingButtonContent } from "../LoadingButtonContent";
-import { validateIsLargerThanMax, validateIsPositive } from "../../utils/inputValidation";
-import stakers from "../../data/stakers";
+import { AmountInputFooter } from "components/AmountInputFooter";
+import { LoadingButtonContent } from "components/LoadingButtonContent";
+import { weiToEthWithDecimals } from "utils/amountFormat";
+import {isPendingTransaction} from "utils/transactions"
+import { validateIsLargerThanMax, validateIsPositive } from "utils/inputValidation";
+import stakers from "data/stakers";
 
 type Props = {
   name: string;
@@ -124,10 +125,10 @@ const Deposit: FC<Props> = ({ name, symbol, logo, tokenBalance, tenderTokenBalan
                     !isTokenApproved ||
                     !depositInput ||
                     depositInput.toString() === "0" ||
-                    depositTx.status === "Mining"
+                    isPendingTransaction(depositTx)
                   }
                   onClick={depositTokens}
-                  label={depositTx.status === "Mining" ? <LoadingButtonContent label="Depositing..." /> : "Deposit"}
+                  label={isPendingTransaction(depositTx)? <LoadingButtonContent label="Depositing..." /> : "Deposit"}
                 />
               </Box>
             </Box>

--- a/packages/app/src/components/actions/deposit.tsx
+++ b/packages/app/src/components/actions/deposit.tsx
@@ -10,7 +10,7 @@ import { InfoCard, Queries } from "@tender/shared/src/index";
 import { AmountInputFooter } from "components/AmountInputFooter";
 import { LoadingButtonContent } from "components/LoadingButtonContent";
 import { weiToEthWithDecimals } from "utils/amountFormat";
-import {isPendingTransaction} from "utils/transactions"
+import { isPendingTransaction } from "utils/transactions";
 import { validateIsLargerThanMax, validateIsPositive } from "utils/inputValidation";
 import stakers from "data/stakers";
 
@@ -128,7 +128,7 @@ const Deposit: FC<Props> = ({ name, symbol, logo, tokenBalance, tenderTokenBalan
                     isPendingTransaction(depositTx)
                   }
                   onClick={depositTokens}
-                  label={isPendingTransaction(depositTx)? <LoadingButtonContent label="Depositing..." /> : "Deposit"}
+                  label={isPendingTransaction(depositTx) ? <LoadingButtonContent label="Depositing..." /> : "Deposit"}
                 />
               </Box>
             </Box>

--- a/packages/app/src/components/approve/ApproveToken.tsx
+++ b/packages/app/src/components/approve/ApproveToken.tsx
@@ -3,7 +3,8 @@ import { constants, Contract } from "ethers";
 import { Box, Button, Tip, Text } from "grommet";
 import { LoadingButtonContent } from "../LoadingButtonContent";
 import { useContractFunction } from "@usedapp/core";
-import { useForceRinkebyFunction } from "../../utils/forceChainIdOnCall";
+import { useForceRinkebyFunction } from "utils/forceChainIdOnCall";
+import { isPendingTransaction } from "utils/transactions";
 
 type Props = {
   symbol: string;
@@ -40,7 +41,7 @@ const ApproveToken: FC<Props> = ({ symbol, spender, show, token }) => {
         label={
           <>
             <Box justify="center" align="center" direction="row" gap="small" pad={{ horizontal: "xsmall" }}>
-              {approveTx.status === "Mining" && <LoadingButtonContent />}
+              {isPendingTransaction(approveTx) && <LoadingButtonContent />}
               <Text weight="normal">Allow Tenderize to spend {symbol}</Text>
               <Tip
                 plain

--- a/packages/app/src/components/farm/farm.tsx
+++ b/packages/app/src/components/farm/farm.tsx
@@ -21,7 +21,7 @@ import { FormAdd, FormClose } from "grommet-icons";
 import { LoadingButtonContent } from "../LoadingButtonContent";
 import { validateIsLargerThanMax, validateIsPositive } from "utils/inputValidation";
 import { useContractFunction, useEthers } from "@usedapp/core";
-import {isPendingTransaction} from "utils/transactions"
+import { isPendingTransaction } from "utils/transactions";
 
 type Props = {
   name: string;

--- a/packages/app/src/components/farm/farm.tsx
+++ b/packages/app/src/components/farm/farm.tsx
@@ -19,8 +19,9 @@ import { useIsTokenApproved } from "../approve/useIsTokenApproved";
 import { AmountInputFooter } from "../AmountInputFooter";
 import { FormAdd, FormClose } from "grommet-icons";
 import { LoadingButtonContent } from "../LoadingButtonContent";
-import { validateIsLargerThanMax, validateIsPositive } from "../../utils/inputValidation";
+import { validateIsLargerThanMax, validateIsPositive } from "utils/inputValidation";
 import { useContractFunction, useEthers } from "@usedapp/core";
+import {isPendingTransaction} from "utils/transactions"
 
 type Props = {
   name: string;
@@ -107,10 +108,10 @@ const Farm: FC<Props> = ({ name, symbol, tokenBalance }) => {
                   primary
                   style={{ width: 467 }}
                   disabled={
-                    !isTokenApproved || !farmInput || farmInput.toString() === "0" || farmTx.status === "Mining"
+                    !isTokenApproved || !farmInput || farmInput.toString() === "0" || isPendingTransaction(farmTx)
                   }
                   onClick={farmLpTokens}
-                  label={farmTx.status === "Mining" ? <LoadingButtonContent label="Farming..." /> : "Farm"}
+                  label={isPendingTransaction(farmTx) ? <LoadingButtonContent label="Farming..." /> : "Farm"}
                 />
               </Box>
             </CardFooter>

--- a/packages/app/src/components/farm/harvest.tsx
+++ b/packages/app/src/components/farm/harvest.tsx
@@ -5,6 +5,7 @@ import { Button, Box, Card, CardHeader, CardBody, CardFooter, Layer, Text, Headi
 import { LoadingButtonContent } from "../LoadingButtonContent";
 import { useContractFunction } from "@usedapp/core";
 import { FormClose } from "grommet-icons";
+import { isPendingTransaction } from "utils/transactions";
 
 type Props = {
   name: string;
@@ -71,9 +72,9 @@ const Harvest: FC<Props> = ({ name, symbol, availableRewards }) => {
               <Button secondary onClick={handleClose} label="Cancel" />
               <Button
                 primary
-                disabled={!availableRewards || availableRewards.toString() === "0" || harvestTx.status === "Mining"}
+                disabled={!availableRewards || availableRewards.toString() === "0" || isPendingTransaction(harvestTx)}
                 onClick={harvestRewards}
-                label={harvestTx.status === "Mining" ? <LoadingButtonContent label="Harvesting..." /> : "Harvest"}
+                label={isPendingTransaction(harvestTx) ? <LoadingButtonContent label="Harvesting..." /> : "Harvest"}
               />
             </CardFooter>
           </Card>

--- a/packages/app/src/components/farm/unfarm.tsx
+++ b/packages/app/src/components/farm/unfarm.tsx
@@ -7,6 +7,7 @@ import { FormClose, FormSubtract } from "grommet-icons";
 import { LoadingButtonContent } from "../LoadingButtonContent";
 import { validateIsLargerThanMax, validateIsPositive } from "../../utils/inputValidation";
 import { useContractFunction } from "@usedapp/core";
+import { isPendingTransaction } from "utils/transactions";
 
 type Props = {
   name: string;
@@ -92,9 +93,9 @@ const Unfarm: FC<Props> = ({ name, symbol, stake }) => {
               <Button primary onClick={handleClose} label="Cancel" />
               <Button
                 secondary
-                disabled={!unfarmInput || unfarmInput.toString() === "0" || unfarmTx.status === "Mining"}
+                disabled={!unfarmInput || unfarmInput.toString() === "0" || isPendingTransaction(unfarmTx)}
                 onClick={unfarmLpTokens}
-                label={unfarmTx.status === "Mining" ? <LoadingButtonContent label="Unfarming..." /> : "Unfarm"}
+                label={isPendingTransaction(unfarmTx) ? <LoadingButtonContent label="Unfarming..." /> : "Unfarm"}
               />
             </CardFooter>
           </Card>

--- a/packages/app/src/components/faucet/index.tsx
+++ b/packages/app/src/components/faucet/index.tsx
@@ -3,33 +3,46 @@ import { contracts } from "@tender/contracts";
 import { Button } from "grommet";
 import { useContractFunction } from "@usedapp/core";
 import Dialog from "components/swap/Dialog";
-
+import { LoadingButtonContent } from "components/LoadingButtonContent";
+import {isPendingTransaction} from "../../utils/transactions"
 type props = {
   symbol: string;
   name: string;
 };
 
 const Faucet: FC<props> = ({ symbol, name }) => {
-  const { send } = useContractFunction(contracts[name].faucet, "request");
+
+  const { state: requestTx, send: request} = useContractFunction(contracts[name].faucet, "request", {
+    transactionName: `Requesting ${symbol} from faucet`,
+  });
 
   // TODO why is this needed
   const requestTokens = () => {
-    send();
+    request();
   };
 
   return (
     <Dialog
+      width="large"
       openButtonLabel="Faucet"
       title="Faucet"
       description={`Get some testnet ${symbol} and ETH (you need ETH to get ${symbol})`}
-      button1={<Button primary onClick={requestTokens} label={`Get ${symbol}`} />}
+      button1={
+        <Button
+          primary 
+          style={{width: "250px"}}
+          onClick={requestTokens} 
+          label={isPendingTransaction(requestTx) ? <LoadingButtonContent label={`Request ${symbol}`} /> : `Get ${symbol}`}
+          disabled={isPendingTransaction(requestTx)}
+        />
+      }
       button2={
         <Button
           primary
+          style={{width: "250px"}}
           href="https://www.rinkebyfaucet.com/"
           target="_blank"
           label="Get ETH"
-          style={{ textAlign: "center" }}
         />
       }
     />

--- a/packages/app/src/components/faucet/index.tsx
+++ b/packages/app/src/components/faucet/index.tsx
@@ -4,15 +4,14 @@ import { Button } from "grommet";
 import { useContractFunction } from "@usedapp/core";
 import Dialog from "components/swap/Dialog";
 import { LoadingButtonContent } from "components/LoadingButtonContent";
-import {isPendingTransaction} from "../../utils/transactions"
+import { isPendingTransaction } from "../../utils/transactions";
 type props = {
   symbol: string;
   name: string;
 };
 
 const Faucet: FC<props> = ({ symbol, name }) => {
-
-  const { state: requestTx, send: request} = useContractFunction(contracts[name].faucet, "request", {
+  const { state: requestTx, send: request } = useContractFunction(contracts[name].faucet, "request", {
     transactionName: `Requesting ${symbol} from faucet`,
   });
 
@@ -23,24 +22,26 @@ const Faucet: FC<props> = ({ symbol, name }) => {
 
   return (
     <Dialog
-      card={{width:"large"}}
+      card={{ width: "large" }}
       width="large"
       openButtonLabel="Faucet"
       title="Faucet"
       description={`Get some testnet ${symbol} and ETH (you need ETH to get ${symbol})`}
       button1={
         <Button
-          primary 
-          style={{width: "250px"}}
-          onClick={requestTokens} 
-          label={isPendingTransaction(requestTx) ? <LoadingButtonContent label={`Request ${symbol}`} /> : `Get ${symbol}`}
+          primary
+          style={{ width: "250px" }}
+          onClick={requestTokens}
+          label={
+            isPendingTransaction(requestTx) ? <LoadingButtonContent label={`Request ${symbol}`} /> : `Get ${symbol}`
+          }
           disabled={isPendingTransaction(requestTx)}
         />
       }
       button2={
         <Button
           primary
-          style={{width: "250px"}}
+          style={{ width: "250px" }}
           href="https://www.rinkebyfaucet.com/"
           target="_blank"
           label="Get ETH"

--- a/packages/app/src/components/faucet/index.tsx
+++ b/packages/app/src/components/faucet/index.tsx
@@ -23,6 +23,7 @@ const Faucet: FC<props> = ({ symbol, name }) => {
 
   return (
     <Dialog
+      card={{width:"large"}}
       width="large"
       openButtonLabel="Faucet"
       title="Faucet"

--- a/packages/app/src/components/swap/ConfirmSwapModal.tsx
+++ b/packages/app/src/components/swap/ConfirmSwapModal.tsx
@@ -22,6 +22,7 @@ import { useContractFunction } from "@usedapp/core";
 import { TransactionListElement } from "components/transactions";
 import { getDeadline } from "utils/tenderSwapHooks";
 import { FormClose } from "grommet-icons";
+import { isPendingTransaction } from "utils/transactions";
 
 type Props = {
   show: boolean;
@@ -68,7 +69,7 @@ const ConfirmSwapModal: FC<Props> = ({
   };
 
   useEffect(() => {
-    if (swapTx.status === "Mining") {
+    if (isPendingTransaction(swapTx)) {
       setConfirmStatus("Submitted");
     } else if (swapTx.status === "Success") {
       setConfirmStatus("Success");

--- a/packages/app/src/components/swap/Dialog.tsx
+++ b/packages/app/src/components/swap/Dialog.tsx
@@ -1,6 +1,7 @@
 import { FC, useState } from "react";
-import { Box, Button, Text, Heading, Layer, Card, CardHeader, CardBody } from "grommet";
+import { Box, Button, Text, Heading, Layer, Card, CardHeader, CardBody, BoxExtendedProps } from "grommet";
 import { FormClose } from "grommet-icons";
+import { HeightType, WidthType } from "grommet/utils";
 
 type props = {
   title: string;
@@ -8,6 +9,9 @@ type props = {
   description?: string;
   button1?: React.ReactNode;
   button2?: React.ReactNode;
+  card?: BoxExtendedProps
+  height?: HeightType | undefined;
+  width?: WidthType | undefined
 };
 
 const Dialog: FC<props> = (props) => {
@@ -24,9 +28,9 @@ const Dialog: FC<props> = (props) => {
           <Card
             flex={false}
             style={{ position: "relative" }}
-            pad={{ horizontal: "medium", bottom: "medium" }}
-            height="medium"
-            width="medium"
+            pad={props.card?.pad || { horizontal: "medium", bottom: "medium" }}
+            height={props.card?.height || "medium"}
+            width={props.card?.width || "medium"}
           >
             <Button
               style={{ position: "absolute", top: 10, right: 10 }}
@@ -41,7 +45,7 @@ const Dialog: FC<props> = (props) => {
             </CardHeader>
             <CardBody>
               <Box flex justify="evenly">
-                <Text>{props.description}</Text>
+                <Text textAlign="center">{props.description}</Text>
                 <Box gap="small" direction="row" justify="center">
                   {props.button1}
                   {props.button2}

--- a/packages/app/src/components/swap/Dialog.tsx
+++ b/packages/app/src/components/swap/Dialog.tsx
@@ -9,9 +9,9 @@ type props = {
   description?: string;
   button1?: React.ReactNode;
   button2?: React.ReactNode;
-  card?: BoxExtendedProps
+  card?: BoxExtendedProps;
   height?: HeightType | undefined;
-  width?: WidthType | undefined
+  width?: WidthType | undefined;
 };
 
 const Dialog: FC<props> = (props) => {

--- a/packages/app/src/components/swap/exit.tsx
+++ b/packages/app/src/components/swap/exit.tsx
@@ -286,7 +286,8 @@ const ExitPool: FC<Props> = ({ name, symbol, lpTokenBalance }) => {
                   disabled={
                     !hasValue(lpSharesInputSingle || lpSharesInputMulti) ||
                     !isLpSharesApproved ||
-                    isPendingTransaction(exitPoolSingleTx) || isPendingTransaction(exitPoolTx)
+                    isPendingTransaction(exitPoolSingleTx) ||
+                    isPendingTransaction(exitPoolTx)
                   }
                   label={
                     isPendingTransaction(exitPoolSingleTx) || isPendingTransaction(exitPoolTx) ? (

--- a/packages/app/src/components/swap/exit.tsx
+++ b/packages/app/src/components/swap/exit.tsx
@@ -30,6 +30,7 @@ import { useContractFunction, useEthers } from "@usedapp/core";
 import { weiToEthWithDecimals } from "../../utils/amountFormat";
 import { getDeadline, useCalculateRemoveLiquidity, useCalculateRemoveLiquidityOneToken } from "utils/tenderSwapHooks";
 import { FormClose } from "grommet-icons";
+import { isPendingTransaction } from "utils/transactions";
 
 type Props = {
   name: string;
@@ -285,11 +286,10 @@ const ExitPool: FC<Props> = ({ name, symbol, lpTokenBalance }) => {
                   disabled={
                     !hasValue(lpSharesInputSingle || lpSharesInputMulti) ||
                     !isLpSharesApproved ||
-                    exitPoolSingleTx.status === "Mining" ||
-                    exitPoolTx.status === "Mining"
+                    isPendingTransaction(exitPoolSingleTx) || isPendingTransaction(exitPoolTx)
                   }
                   label={
-                    exitPoolSingleTx.status === "Mining" || exitPoolTx.status === "Mining" ? (
+                    isPendingTransaction(exitPoolSingleTx) || isPendingTransaction(exitPoolTx) ? (
                       <LoadingButtonContent label="Removing Liquidity..." />
                     ) : (
                       "Remove Liquidity"

--- a/packages/app/src/components/swap/join.tsx
+++ b/packages/app/src/components/swap/join.tsx
@@ -16,15 +16,16 @@ import {
   Text,
   Heading,
 } from "grommet";
-import ApproveToken from "../approve/ApproveToken";
-import { useIsTokenApproved } from "../approve/useIsTokenApproved";
-import { useCalculateLpTokenAmount, getDeadline } from "../../utils/tenderSwapHooks";
-import { AmountInputFooter } from "../AmountInputFooter";
-import { LoadingButtonContent } from "../LoadingButtonContent";
-import { validateIsPositive, validateIsLargerThanMax, hasValue } from "../../utils/inputValidation";
-import stakers from "../../data/stakers";
+import ApproveToken from "components/approve/ApproveToken";
+import { useIsTokenApproved } from "components/approve/useIsTokenApproved";
+import { AmountInputFooter } from "components/AmountInputFooter";
+import { LoadingButtonContent } from "components/LoadingButtonContent";
+import { useCalculateLpTokenAmount, getDeadline } from "utils/tenderSwapHooks";
+import { validateIsPositive, validateIsLargerThanMax, hasValue } from "utils/inputValidation";
+import {isPendingTransaction} from "utils/transactions"
+import { weiToEthWithDecimals } from "utils/amountFormat";
+import stakers from "data/stakers";
 import { useContractFunction, useEthers } from "@usedapp/core";
-import { weiToEthWithDecimals } from "../../utils/amountFormat";
 import { FormClose } from "grommet-icons";
 
 type Props = {
@@ -81,7 +82,7 @@ const JoinPool: FC<Props> = ({ name, symbol, tokenBalance, tenderTokenBalance })
   const isButtonDisabled = () => {
     return (
       !(hasValue(tokenInput) && hasValue(tenderInput) && isTokenApproved && isTenderApproved) ||
-      addLiquidityTx.status === "Mining"
+      isPendingTransaction(addLiquidityTx)
     );
   };
 
@@ -225,7 +226,7 @@ const JoinPool: FC<Props> = ({ name, symbol, tokenBalance, tenderTokenBalance })
                   onClick={handleAddLiquidity}
                   disabled={isButtonDisabled()}
                   label={
-                    addLiquidityTx.status === "Mining" ? (
+                    isPendingTransaction(addLiquidityTx)? (
                       <LoadingButtonContent label="Adding Liquidity..." />
                     ) : (
                       "Add Liquidity"

--- a/packages/app/src/components/swap/join.tsx
+++ b/packages/app/src/components/swap/join.tsx
@@ -22,7 +22,7 @@ import { AmountInputFooter } from "components/AmountInputFooter";
 import { LoadingButtonContent } from "components/LoadingButtonContent";
 import { useCalculateLpTokenAmount, getDeadline } from "utils/tenderSwapHooks";
 import { validateIsPositive, validateIsLargerThanMax, hasValue } from "utils/inputValidation";
-import {isPendingTransaction} from "utils/transactions"
+import { isPendingTransaction } from "utils/transactions";
 import { weiToEthWithDecimals } from "utils/amountFormat";
 import stakers from "data/stakers";
 import { useContractFunction, useEthers } from "@usedapp/core";
@@ -226,7 +226,7 @@ const JoinPool: FC<Props> = ({ name, symbol, tokenBalance, tenderTokenBalance })
                   onClick={handleAddLiquidity}
                   disabled={isButtonDisabled()}
                   label={
-                    isPendingTransaction(addLiquidityTx)? (
+                    isPendingTransaction(addLiquidityTx) ? (
                       <LoadingButtonContent label="Adding Liquidity..." />
                     ) : (
                       "Add Liquidity"

--- a/packages/app/src/utils/transactions.ts
+++ b/packages/app/src/utils/transactions.ts
@@ -1,16 +1,21 @@
-import { TransactionStatus } from "@usedapp/core"
+import { TransactionStatus } from "@usedapp/core";
 
 export const isPendingTransaction = (tx: TransactionStatus) => {
-    switch(tx.status){
-        case "Mining": return true
-        case "PendingSignature": return true
-        default: return false
-    }
-}
+  switch (tx.status) {
+    case "Mining":
+      return true;
+    case "PendingSignature":
+      return true;
+    default:
+      return false;
+  }
+};
 
 export const isSuccesfulTransaction = (tx: TransactionStatus) => {
-    switch(tx.status) {
-        case "Success": return true
-        default: return false
-    }
-}
+  switch (tx.status) {
+    case "Success":
+      return true;
+    default:
+      return false;
+  }
+};

--- a/packages/app/src/utils/transactions.ts
+++ b/packages/app/src/utils/transactions.ts
@@ -1,0 +1,15 @@
+import { TransactionStatus } from "@usedapp/core"
+
+export const isPendingTransaction = (tx: TransactionStatus) => {
+    switch(tx.status){
+        case "Mining": return true
+        default: return false
+    }
+}
+
+export const isSuccesfulTransaction = (tx: TransactionStatus) => {
+    switch(tx.status) {
+        case "Success": return true
+        default: return false
+    }
+}

--- a/packages/app/src/utils/transactions.ts
+++ b/packages/app/src/utils/transactions.ts
@@ -3,6 +3,7 @@ import { TransactionStatus } from "@usedapp/core"
 export const isPendingTransaction = (tx: TransactionStatus) => {
     switch(tx.status){
         case "Mining": return true
+        case "PendingSignature": return true
         default: return false
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3171,6 +3171,20 @@
     lodash.merge "^4.6.2"
     nanoid "3.1.22"
 
+"@usedapp/core@^0.9.1":
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/@usedapp/core/-/core-0.9.1.tgz#b895caabf4bfe7f1bfda00651b60812b3437156f"
+  integrity sha512-Xhv3EZPVdkwn1J1qX7vC4GwPEfYU03cqRdWf2HupkWoEyCwkj/QrOpeoYz0TEWVlIle948kaBhDe+HKr48cKSw==
+  dependencies:
+    "@types/react" "17.0.1"
+    "@uniswap/token-lists" "^1.0.0-beta.27"
+    "@web3-react/core" "6.1.1"
+    "@web3-react/injected-connector" "6.0.7"
+    "@web3-react/network-connector" "6.1.5"
+    ethers "5.5.1"
+    lodash.merge "^4.6.2"
+    nanoid "3.1.22"
+
 "@walletconnect/browser-utils@^1.6.5":
   version "1.6.5"
   resolved "https://registry.yarnpkg.com/@walletconnect/browser-utils/-/browser-utils-1.6.5.tgz#01180682e90b95384e820191a1c6ad4a78729439"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5325,6 +5325,13 @@ buffer@^6.0.3:
     base64-js "^1.3.1"
     ieee754 "^1.2.1"
 
+bufferutil@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/bufferutil/-/bufferutil-4.0.6.tgz#ebd6c67c7922a0e902f053e5d8be5ec850e48433"
+  integrity sha512-jduaYOYtnio4aIAyc6UbvPCVcgq7nYpVnucyxr6eCYg/Woad9Hf/oxxBRDnGGjPfjUm6j5O/uBWhIu4iLebFaw==
+  dependencies:
+    node-gyp-build "^4.3.0"
+
 builtin-modules@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.2.0.tgz#45d5db99e7ee5e6bc4f362e008bf917ab5049887"
@@ -12096,6 +12103,11 @@ node-gyp-build@^4.2.0:
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.2.3.tgz#ce6277f853835f718829efb47db20f3e4d9c4739"
   integrity sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==
 
+node-gyp-build@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.3.0.tgz#9f256b03e5826150be39c764bf51e993946d71a3"
+  integrity sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==
+
 node-html-parser@1.4.9:
   version "1.4.9"
   resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-1.4.9.tgz#3c8f6cac46479fae5800725edb532e9ae8fd816c"
@@ -16549,6 +16561,13 @@ use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
+
+utf-8-validate@^5.0.8:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/utf-8-validate/-/utf-8-validate-5.0.8.tgz#4a735a61661dbb1c59a0868c397d2fe263f14e58"
+  integrity sha512-k4dW/Qja1BYDl2qD4tOMB9PFVha/UJtxTc1cXYOe3WwA/2m0Yn4qB7wLMpJyLJ/7DR0XnTut3HsCSzDT4ZvKgA==
+  dependencies:
+    node-gyp-build "^4.3.0"
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Previously when requesting tokens from faucet the notification popup would show "transaction started: undefined". This PR does the following:

- Add a proper description for request from faucet
- Upgrade to `usedapp/core:v0.9.1`
- Create a helper `isPendingTransaction` which checks for `Mining` and `PendingSignature` status
- Use `isPendingTransaction` helper across the board
- Change modal and button sizes for faucet, make `swap/Dialog` component more customisable by adding `BoxExtendedProps`