### PR TITLE
App: Fix dialogs and form uniformity

### DIFF
--- a/packages/app/src/components/account/AccountModal.tsx
+++ b/packages/app/src/components/account/AccountModal.tsx
@@ -35,7 +35,7 @@ export const AccountModal: FC<AccountModalProps> = ({ showModal, setShowModal })
         >
           <Card flex={false}>
             <Box pad="medium" gap="medium">
-              <CardHeader>
+              <CardHeader justify="center" pad="none">
                 <Heading level={2} alignSelf="center">
                   Account info
                 </Heading>

--- a/packages/app/src/components/account/index.tsx
+++ b/packages/app/src/components/account/index.tsx
@@ -83,7 +83,7 @@ export const AccountButton: FC<{ config: TenderizeConfig }> = ({ config }) => {
               icon={<FormClose />}
               onClick={handleCloseWalletPicker}
             />
-            <CardHeader justify="center">
+            <CardHeader justify="center" pad="none">
               <Heading level={2} alignSelf="center">
                 Connect Wallet
               </Heading>

--- a/packages/app/src/components/actions/deposit.tsx
+++ b/packages/app/src/components/actions/deposit.tsx
@@ -96,7 +96,7 @@ const Deposit: FC<Props> = ({ name, symbol, logo, tokenBalance, tenderTokenBalan
                 <TextInput
                   value={depositInput}
                   onChange={handleInputChange}
-                  type="text"
+                  type="number"
                   icon={
                     <Box pad="xsmall" direction="row" align="center" gap="small">
                       <Image height="35" src={`/${logo}`} />

--- a/packages/app/src/components/actions/deposit.tsx
+++ b/packages/app/src/components/actions/deposit.tsx
@@ -15,18 +15,18 @@ import { validateIsLargerThanMax, validateIsPositive } from "utils/inputValidati
 import stakers from "data/stakers";
 
 type Props = {
-  name: string;
+  protocolName: string;
   symbol: string;
   logo: string;
   tokenBalance: BigNumberish;
   tenderTokenBalance: BigNumberish;
 };
 
-const Deposit: FC<Props> = ({ name, symbol, logo, tokenBalance, tenderTokenBalance }) => {
+const Deposit: FC<Props> = ({ protocolName, symbol, logo, tokenBalance, tenderTokenBalance }) => {
   const [depositInput, setDepositInput] = useState("");
   const { account } = useEthers();
 
-  const subgraphName = stakers[name].subgraphId;
+  const subgraphName = stakers[protocolName].subgraphId;
   const { data, refetch } = useQuery<Queries.UserDeploymentsType>(Queries.GetUserDeployments, {
     variables: { id: `${account?.toLowerCase()}_${subgraphName}` },
   });
@@ -46,7 +46,7 @@ const Deposit: FC<Props> = ({ name, symbol, logo, tokenBalance, tenderTokenBalan
     setDepositInput(val);
   };
 
-  const { state: depositTx, send: deposit } = useContractFunction(contracts[name].tenderizer, "deposit", {
+  const { state: depositTx, send: deposit } = useContractFunction(contracts[protocolName].tenderizer, "deposit", {
     transactionName: `Deposit ${symbol}`,
   });
 
@@ -56,7 +56,12 @@ const Deposit: FC<Props> = ({ name, symbol, logo, tokenBalance, tenderTokenBalan
     setDepositInput("");
   };
 
-  const isTokenApproved = useIsTokenApproved(addresses[name].token, account, addresses[name].tenderizer, depositInput);
+  const isTokenApproved = useIsTokenApproved(
+    addresses[protocolName].token,
+    account,
+    addresses[protocolName].tenderizer,
+    depositInput
+  );
 
   const claimedRewards = BigNumber.from(data?.userDeployments?.[0]?.claimedRewards ?? "0");
   const tenderizerStake = BigNumber.from(data?.userDeployments?.[0]?.tenderizerStake ?? "0");
@@ -90,7 +95,7 @@ const Deposit: FC<Props> = ({ name, symbol, logo, tokenBalance, tenderTokenBalan
               <FormField
                 fill
                 label="Deposit Amount"
-                name="depositAmount"
+                protocolName="depositAmount"
                 validate={[validateIsPositive(depositInput), validateIsLargerThanMax(depositInput, tokenBalance)]}
               >
                 <TextInput
@@ -114,8 +119,8 @@ const Deposit: FC<Props> = ({ name, symbol, logo, tokenBalance, tenderTokenBalan
               <Box gap="small" direction="column">
                 <ApproveToken
                   symbol={symbol}
-                  spender={addresses[name].tenderizer}
-                  token={contracts[name].token}
+                  spender={addresses[protocolName].tenderizer}
+                  token={contracts[protocolName].token}
                   show={!isTokenApproved}
                 />
                 <Button

--- a/packages/app/src/components/farm/farm.tsx
+++ b/packages/app/src/components/farm/farm.tsx
@@ -96,7 +96,7 @@ const Farm: FC<Props> = ({ name: protocolName, symbol, tokenBalance }) => {
                     <TextInput
                       value={farmInput}
                       onChange={handleFarmInputChange}
-                      type="text"
+                      type="number"
                       placeholder={"0"}
                       icon={
                         <Box pad="xsmall" direction="row" align="center" gap="small">

--- a/packages/app/src/components/farm/farm.tsx
+++ b/packages/app/src/components/farm/farm.tsx
@@ -12,6 +12,7 @@ import {
   Layer,
   Form,
   FormField,
+  Text,
   TextInput,
 } from "grommet";
 import { useIsTokenApproved } from "../approve/useIsTokenApproved";
@@ -68,7 +69,12 @@ const Farm: FC<Props> = ({ name: protocolName, symbol, tokenBalance }) => {
       <Button primary onClick={handleShow} label="Farm" reverse icon={<FormAdd color="white" />} />
       {show && (
         <Layer style={{ overflow: "auto" }} animation="fadeIn" onEsc={handleClose} onClickOutside={handleClose}>
-          <Card flex={false} style={{ position: "relative" }} pad="medium" width="large">
+          <Card
+            flex={false}
+            style={{ position: "relative" }}
+            pad={{ vertical: "medium", horizontal: "xlarge" }}
+            width="large"
+          >
             <Button
               style={{ position: "absolute", top: 10, right: 10 }}
               plain
@@ -81,23 +87,31 @@ const Farm: FC<Props> = ({ name: protocolName, symbol, tokenBalance }) => {
               </Heading>
             </CardHeader>
             <CardBody>
-              <Form validate="change">
-                <FormField
-                  name="farmInput"
-                  validate={[validateIsPositive(farmInput), validateIsLargerThanMax(farmInput, tokenBalance)]}
-                >
-                  <TextInput
-                    value={farmInput}
-                    onChange={handleFarmInputChange}
-                    type="text"
-                    placeholder={"0 " + symbol}
-                  />
-                  <AmountInputFooter
-                    label={`Balance: ${utils.formatEther(tokenBalance?.toString() || "0")} ${symbol}`}
-                    onClick={maxDeposit}
-                  />
-                </FormField>
-              </Form>
+              <Box pad={{ top: "medium", horizontal: "large" }} align="center">
+                <Form validate="change" style={{ width: "100%" }}>
+                  <FormField
+                    name="farmInput"
+                    validate={[validateIsPositive(farmInput), validateIsLargerThanMax(farmInput, tokenBalance)]}
+                  >
+                    <TextInput
+                      value={farmInput}
+                      onChange={handleFarmInputChange}
+                      type="text"
+                      placeholder={"0"}
+                      icon={
+                        <Box pad="xsmall" direction="row" align="center" gap="small">
+                          <Text>{symbol}</Text>
+                        </Box>
+                      }
+                      style={{ textAlign: "right", padding: "20px 50px" }}
+                    />
+                    <AmountInputFooter
+                      label={`Balance: ${utils.formatEther(tokenBalance?.toString() || "0")} ${symbol}`}
+                      onClick={maxDeposit}
+                    />
+                  </FormField>
+                </Form>
+              </Box>
             </CardBody>
             <CardFooter align="center" justify="center" pad={{ top: "medium" }}>
               <Box justify="center" gap="small">

--- a/packages/app/src/components/farm/farm.tsx
+++ b/packages/app/src/components/farm/farm.tsx
@@ -81,37 +81,35 @@ const Farm: FC<Props> = ({ name: protocolName, symbol, tokenBalance }) => {
               icon={<FormClose />}
               onClick={handleClose}
             />
-            <CardHeader justify="center" pad={{ bottom: "small" }}>
+            <CardHeader justify="center" pad="none">
               <Heading level={2} alignSelf="center">
                 {`Farm ${symbol}`}
               </Heading>
             </CardHeader>
-            <CardBody>
-              <Box pad={{ top: "medium", horizontal: "large" }} align="center">
-                <Form validate="change" style={{ width: "100%" }}>
-                  <FormField
-                    name="farmInput"
-                    validate={[validateIsPositive(farmInput), validateIsLargerThanMax(farmInput, tokenBalance)]}
-                  >
-                    <TextInput
-                      value={farmInput}
-                      onChange={handleFarmInputChange}
-                      type="number"
-                      placeholder={"0"}
-                      icon={
-                        <Box pad="xsmall" direction="row" align="center" gap="small">
-                          <Text>{symbol}</Text>
-                        </Box>
-                      }
-                      style={{ textAlign: "right", padding: "20px 50px" }}
-                    />
-                    <AmountInputFooter
-                      label={`Balance: ${utils.formatEther(tokenBalance?.toString() || "0")} ${symbol}`}
-                      onClick={maxDeposit}
-                    />
-                  </FormField>
-                </Form>
-              </Box>
+            <CardBody pad={{ top: "medium", horizontal: "large" }} align="center">
+              <Form validate="change" style={{ width: "100%" }}>
+                <FormField
+                  name="farmInput"
+                  validate={[validateIsPositive(farmInput), validateIsLargerThanMax(farmInput, tokenBalance)]}
+                >
+                  <TextInput
+                    value={farmInput}
+                    onChange={handleFarmInputChange}
+                    type="number"
+                    placeholder={"0"}
+                    icon={
+                      <Box pad="xsmall" direction="row" align="center" gap="small">
+                        <Text>{symbol}</Text>
+                      </Box>
+                    }
+                    style={{ textAlign: "right", padding: "20px 50px" }}
+                  />
+                  <AmountInputFooter
+                    label={`Balance: ${utils.formatEther(tokenBalance?.toString() || "0")} ${symbol}`}
+                    onClick={maxDeposit}
+                  />
+                </FormField>
+              </Form>
             </CardBody>
             <CardFooter align="center" justify="center" pad={{ top: "medium" }}>
               <Box justify="center" gap="small">

--- a/packages/app/src/components/farm/farm.tsx
+++ b/packages/app/src/components/farm/farm.tsx
@@ -25,12 +25,12 @@ import { isPendingTransaction } from "utils/transactions";
 import { useFarm } from "utils/tenderFarmHooks";
 
 type Props = {
-  name: string;
+  protocolName: string;
   symbol: string;
   tokenBalance: BigNumberish;
 };
 
-const Farm: FC<Props> = ({ name: protocolName, symbol, tokenBalance }) => {
+const Farm: FC<Props> = ({ protocolName, symbol, tokenBalance }) => {
   const [show, setShow] = useState(false);
   const { account } = useEthers();
 
@@ -89,7 +89,7 @@ const Farm: FC<Props> = ({ name: protocolName, symbol, tokenBalance }) => {
             <CardBody pad={{ top: "medium", horizontal: "large" }} align="center">
               <Form validate="change" style={{ width: "100%" }}>
                 <FormField
-                  name="farmInput"
+                  protocolName="farmInput"
                   validate={[validateIsPositive(farmInput), validateIsLargerThanMax(farmInput, tokenBalance)]}
                 >
                   <TextInput

--- a/packages/app/src/components/farm/harvest.tsx
+++ b/packages/app/src/components/farm/harvest.tsx
@@ -1,11 +1,24 @@
 import { FC, useState } from "react";
 import { contracts } from "@tender/contracts";
-import { BigNumberish, utils } from "ethers";
-import { Button, Box, Card, CardHeader, CardBody, CardFooter, Layer, Text, Heading } from "grommet";
+import { BigNumberish } from "ethers";
+import {
+  Button,
+  Box,
+  Card,
+  CardHeader,
+  CardBody,
+  CardFooter,
+  Layer,
+  Text,
+  Heading,
+  FormField,
+  TextInput,
+} from "grommet";
 import { LoadingButtonContent } from "../LoadingButtonContent";
 import { useContractFunction } from "@usedapp/core";
 import { FormClose } from "grommet-icons";
 import { isPendingTransaction } from "utils/transactions";
+import { weiToEthWithDecimals } from "utils/amountFormat";
 
 type Props = {
   name: string;
@@ -58,15 +71,27 @@ const Harvest: FC<Props> = ({ name, symbol, availableRewards }) => {
               icon={<FormClose />}
               onClick={handleClose}
             />
-            <CardHeader justify="center" pad={{ bottom: "small" }}>
+            <CardHeader justify="center" pad="none">
               <Heading level={2} alignSelf="center">
                 {`Harvest ${symbol}`}
               </Heading>
             </CardHeader>
-            <CardBody align="center">
-              <Text>
-                Available for harvest: {`${utils.formatEther(availableRewards?.toString() || "0")} ${symbol}`}
-              </Text>
+            <CardBody pad={{ top: "medium", horizontal: "large" }} align="center">
+              <FormField label="Available for harvest:">
+                <TextInput
+                  readOnly
+                  disabled
+                  value={weiToEthWithDecimals(availableRewards, 6)}
+                  placeholder={"0"}
+                  type="number"
+                  style={{ textAlign: "right", padding: "20px 50px" }}
+                  icon={
+                    <Box pad="xsmall" direction="row" align="center" gap="small">
+                      <Text>{symbol}</Text>
+                    </Box>
+                  }
+                />
+              </FormField>
             </CardBody>
             <CardFooter align="center" justify="center" pad={{ top: "medium" }}>
               <Button secondary onClick={handleClose} label="Cancel" />

--- a/packages/app/src/components/farm/harvest.tsx
+++ b/packages/app/src/components/farm/harvest.tsx
@@ -9,6 +9,8 @@ import {
   CardBody,
   CardFooter,
   Layer,
+  Form,
+  Image,
   Text,
   Heading,
   FormField,
@@ -19,15 +21,17 @@ import { useContractFunction } from "@usedapp/core";
 import { FormClose } from "grommet-icons";
 import { isPendingTransaction } from "utils/transactions";
 import { weiToEthWithDecimals } from "utils/amountFormat";
+import stakers from "../../data/stakers";
 
 type Props = {
-  name: string;
+  protocolName: string;
   symbol: string;
   availableRewards: BigNumberish;
 };
 
-const Harvest: FC<Props> = ({ name, symbol, availableRewards }) => {
+const Harvest: FC<Props> = ({ protocolName, symbol, availableRewards }) => {
   // Component state & helpers
+  const tenderLogo = `/${stakers[protocolName].bwTenderLogo}`;
 
   const [show, setShow] = useState(false);
 
@@ -35,7 +39,7 @@ const Harvest: FC<Props> = ({ name, symbol, availableRewards }) => {
   const handleShow = () => setShow(true);
 
   // Contract Functions
-  const { state: harvestTx, send: harvest } = useContractFunction(contracts[name].tenderFarm, "harvest", {
+  const { state: harvestTx, send: harvest } = useContractFunction(contracts[protocolName].tenderFarm, "harvest", {
     transactionName: `Harvest ${symbol}`,
   });
   const harvestRewards = (e: any) => {
@@ -52,7 +56,7 @@ const Harvest: FC<Props> = ({ name, symbol, availableRewards }) => {
         label={
           <Box direction="row" align="center" justify="center" gap="small">
             <Text>Harvest</Text>
-            <img height={18} width={8.69} src={"/harvest.svg"} alt="" />
+            <Image height={18} width={8.69} src={"/harvest.svg"} alt="" />
           </Box>
         }
         style={{ color: "#4E66DE" }}
@@ -64,7 +68,12 @@ const Harvest: FC<Props> = ({ name, symbol, availableRewards }) => {
           onEsc={() => setShow(false)}
           onClickOutside={() => setShow(false)}
         >
-          <Card flex={false} style={{ position: "relative" }} pad="medium" width="large">
+          <Card
+            flex={false}
+            style={{ position: "relative" }}
+            pad={{ vertical: "medium", horizontal: "xlarge" }}
+            width="large"
+          >
             <Button
               style={{ position: "absolute", top: 10, right: 10 }}
               plain
@@ -77,30 +86,36 @@ const Harvest: FC<Props> = ({ name, symbol, availableRewards }) => {
               </Heading>
             </CardHeader>
             <CardBody pad={{ top: "medium", horizontal: "large" }} align="center">
-              <FormField label="Available for harvest:">
-                <TextInput
-                  readOnly
-                  disabled
-                  value={weiToEthWithDecimals(availableRewards, 6)}
-                  placeholder={"0"}
-                  type="number"
-                  style={{ textAlign: "right", padding: "20px 50px" }}
-                  icon={
-                    <Box pad="xsmall" direction="row" align="center" gap="small">
-                      <Text>{symbol}</Text>
-                    </Box>
-                  }
-                />
-              </FormField>
+              <Form style={{ width: "100%" }}>
+                <FormField label="Available for harvest:">
+                  <TextInput
+                    readOnly
+                    disabled
+                    value={weiToEthWithDecimals(availableRewards, 6)}
+                    placeholder={"0"}
+                    type="number"
+                    style={{ textAlign: "right", padding: "20px 50px" }}
+                    icon={
+                      <Box pad="xsmall" direction="row" align="center" gap="small">
+                        <Image height="35" src={tenderLogo} />
+                        <Text>{symbol}</Text>
+                      </Box>
+                    }
+                  />
+                </FormField>
+              </Form>
             </CardBody>
-            <CardFooter align="center" justify="center" pad={{ top: "medium" }}>
-              <Button secondary onClick={handleClose} label="Cancel" />
-              <Button
-                primary
-                disabled={!availableRewards || availableRewards.toString() === "0" || isPendingTransaction(harvestTx)}
-                onClick={harvestRewards}
-                label={isPendingTransaction(harvestTx) ? <LoadingButtonContent label="Harvesting..." /> : "Harvest"}
-              />
+            <CardFooter align="center" justify="center" pad={{ vertical: "medium" }}>
+              <Box direction="row" style={{ width: "100%" }} pad={{ horizontal: "large" }} justify="center" gap="small">
+                <Button style={{ width: "100%" }} secondary onClick={handleClose} label="Cancel" />
+                <Button
+                  style={{ width: "100%" }}
+                  primary
+                  disabled={!availableRewards || availableRewards.toString() === "0" || isPendingTransaction(harvestTx)}
+                  onClick={harvestRewards}
+                  label={isPendingTransaction(harvestTx) ? <LoadingButtonContent label="Harvesting..." /> : "Harvest"}
+                />
+              </Box>
             </CardFooter>
           </Card>
         </Layer>

--- a/packages/app/src/components/farm/index.tsx
+++ b/packages/app/src/components/farm/index.tsx
@@ -12,37 +12,37 @@ import { weiToEthWithDecimals } from "../../utils/amountFormat";
 import stakers from "../../data/stakers";
 
 type Props = {
-  name: string;
+  protocolName: string;
   symbol: string;
   account: string;
   lpTokenBalance: BigNumberish;
 };
 
-const TenderFarm: FC<Props> = ({ name, symbol, account, lpTokenBalance }) => {
+const TenderFarm: FC<Props> = ({ protocolName, symbol, account, lpTokenBalance }) => {
   const symbolFull = `t${symbol}-${symbol}-SWAP`;
 
   const stakeOf = useContractCall({
-    abi: contracts[name].tenderFarm.interface,
-    address: addresses[name].tenderFarm.toLowerCase(),
+    abi: contracts[protocolName].tenderFarm.interface,
+    address: addresses[protocolName].tenderFarm.toLowerCase(),
     method: "stakeOf",
     args: [account],
   });
 
   // const totalStake = useContractCall({
-  //   abi: contracts[name].tenderFarm.interface,
-  //   address: addresses[name].tenderFarm,
+  //   abi: contracts[protocolName].tenderFarm.interface,
+  //   address: addresses[protocolName].tenderFarm,
   //   method: "nextTotalStake",
   //   args: [],
   // });
 
   const availableRewards = useContractCall({
-    abi: contracts[name].tenderFarm.interface,
-    address: addresses[name].tenderFarm,
+    abi: contracts[protocolName].tenderFarm.interface,
+    address: addresses[protocolName].tenderFarm,
     method: "availableRewards",
     args: [account],
   });
 
-  const subgraphName = stakers[name].subgraphId;
+  const subgraphName = stakers[protocolName].subgraphId;
   const { data: userData, refetch } = useQuery<Queries.UserDeploymentsType>(Queries.GetUserDeployments, {
     variables: { id: `${account?.toLowerCase()}_${subgraphName}` },
   });
@@ -79,9 +79,9 @@ const TenderFarm: FC<Props> = ({ name, symbol, account, lpTokenBalance }) => {
         </Box>
       </Box>
       <Box flex justify="around" align="center" direction="row" pad={{ bottom: "large" }}>
-        <Farm name={name} symbol={symbolFull} tokenBalance={lpTokenBalance || "0"} />
-        <Unfarm name={name} symbol={symbolFull} stake={stakeOf || "0"} />
-        <Harvest name={name} symbol={`tender${symbol}`} availableRewards={availableRewards || "0"} />
+        <Farm protocolName={protocolName} symbol={symbolFull} tokenBalance={lpTokenBalance || "0"} />
+        <Unfarm protocolName={protocolName} symbol={symbolFull} stake={stakeOf || "0"} />
+        <Harvest protocolName={protocolName} symbol={`tender${symbol}`} availableRewards={availableRewards || "0"} />
       </Box>
       {/* <Box gap="large" justify="center" direction="row">
         <Box

--- a/packages/app/src/components/farm/unfarm.tsx
+++ b/packages/app/src/components/farm/unfarm.tsx
@@ -83,7 +83,7 @@ const Unfarm: FC<Props> = ({ name, symbol, stake }) => {
               icon={<FormClose />}
               onClick={handleClose}
             />
-            <CardHeader justify="center" pad={{ bottom: "small" }}>
+            <CardHeader justify="center" pad="none">
               <Heading level={2} alignSelf="center">
                 {`Unfarm ${symbol}`}
               </Heading>

--- a/packages/app/src/components/farm/unfarm.tsx
+++ b/packages/app/src/components/farm/unfarm.tsx
@@ -23,12 +23,12 @@ import { useContractFunction } from "@usedapp/core";
 import { isPendingTransaction } from "utils/transactions";
 
 type Props = {
-  name: string;
+  protocolName: string;
   symbol: string;
   stake: BigNumberish;
 };
 
-const Unfarm: FC<Props> = ({ name, symbol, stake }) => {
+const Unfarm: FC<Props> = ({ protocolName, symbol, stake }) => {
   const [show, setShow] = useState(false);
 
   const handleClose = () => setShow(false);
@@ -45,7 +45,7 @@ const Unfarm: FC<Props> = ({ name, symbol, stake }) => {
     setUnfarmInput(utils.formatEther(stake.toString() || "0"));
   };
 
-  const { state: unfarmTx, send: unfarm } = useContractFunction(contracts[name].tenderFarm, "unfarm", {
+  const { state: unfarmTx, send: unfarm } = useContractFunction(contracts[protocolName].tenderFarm, "unfarm", {
     transactionName: `Unfarm ${symbol}`,
   });
   const unfarmLpTokens = async (e: any) => {

--- a/packages/app/src/components/farm/unfarm.tsx
+++ b/packages/app/src/components/farm/unfarm.tsx
@@ -1,7 +1,20 @@
 import { FC, useState } from "react";
 import { contracts } from "@tender/contracts";
 import { BigNumberish, utils } from "ethers";
-import { Button, Card, CardHeader, CardBody, CardFooter, Layer, Form, FormField, TextInput, Heading } from "grommet";
+import {
+  Box,
+  Button,
+  Card,
+  CardHeader,
+  CardBody,
+  CardFooter,
+  Layer,
+  Form,
+  FormField,
+  Text,
+  TextInput,
+  Heading,
+} from "grommet";
 import { AmountInputFooter } from "../AmountInputFooter";
 import { FormClose, FormSubtract } from "grommet-icons";
 import { LoadingButtonContent } from "../LoadingButtonContent";
@@ -58,7 +71,12 @@ const Unfarm: FC<Props> = ({ name, symbol, stake }) => {
           onEsc={() => setShow(false)}
           onClickOutside={() => setShow(false)}
         >
-          <Card flex={false} style={{ position: "relative" }} pad="medium" width="large">
+          <Card
+            flex={false}
+            style={{ position: "relative" }}
+            pad={{ vertical: "medium", horizontal: "xlarge" }}
+            width="large"
+          >
             <Button
               style={{ position: "absolute", top: 10, right: 10 }}
               plain
@@ -71,32 +89,43 @@ const Unfarm: FC<Props> = ({ name, symbol, stake }) => {
               </Heading>
             </CardHeader>
             <CardBody>
-              <Form validate="change">
-                <FormField
-                  label="Unfarm Amount"
-                  validate={[validateIsPositive(unfarmInput), validateIsLargerThanMax(unfarmInput, stake)]}
-                >
-                  <TextInput
-                    value={unfarmInput}
-                    onChange={handleUnfarmInputChange}
-                    type="text"
-                    placeholder={"0 " + symbol}
-                  />
-                  <AmountInputFooter
-                    label={`Current Stake: ${utils.formatEther(stake?.toString() || "0")} ${symbol}`}
-                    onClick={maxUnfarm}
-                  />
-                </FormField>
-              </Form>
+              <Box pad={{ top: "medium", horizontal: "large" }} align="center">
+                <Form validate="change" style={{ width: "100%" }}>
+                  <FormField
+                    label="Unfarm Amount"
+                    validate={[validateIsPositive(unfarmInput), validateIsLargerThanMax(unfarmInput, stake)]}
+                  >
+                    <TextInput
+                      value={unfarmInput}
+                      onChange={handleUnfarmInputChange}
+                      type="text"
+                      placeholder={"0 "}
+                      icon={
+                        <Box pad="xsmall" direction="row" align="center" gap="small">
+                          <Text>{symbol}</Text>
+                        </Box>
+                      }
+                      style={{ textAlign: "right", padding: "20px 50px" }}
+                    />
+                    <AmountInputFooter
+                      label={`Current Stake: ${utils.formatEther(stake?.toString() || "0")} ${symbol}`}
+                      onClick={maxUnfarm}
+                    />
+                  </FormField>
+                </Form>
+              </Box>
             </CardBody>
-            <CardFooter align="center" justify="center" pad={{ top: "medium" }}>
-              <Button primary onClick={handleClose} label="Cancel" />
-              <Button
-                secondary
-                disabled={!unfarmInput || unfarmInput.toString() === "0" || isPendingTransaction(unfarmTx)}
-                onClick={unfarmLpTokens}
-                label={isPendingTransaction(unfarmTx) ? <LoadingButtonContent label="Unfarming..." /> : "Unfarm"}
-              />
+            <CardFooter align="center" justify="center" pad={{ vertical: "medium" }}>
+              <Box direction="row" style={{ width: "100%" }} pad={{ horizontal: "large" }} justify="center" gap="small">
+                <Button style={{ width: "100%" }} primary onClick={handleClose} label="Cancel" />
+                <Button
+                  style={{ width: "100%" }}
+                  secondary
+                  disabled={!unfarmInput || unfarmInput.toString() === "0" || isPendingTransaction(unfarmTx)}
+                  onClick={unfarmLpTokens}
+                  label={isPendingTransaction(unfarmTx) ? <LoadingButtonContent label="Unfarming..." /> : "Unfarm"}
+                />
+              </Box>
             </CardFooter>
           </Card>
         </Layer>

--- a/packages/app/src/components/farm/unfarm.tsx
+++ b/packages/app/src/components/farm/unfarm.tsx
@@ -98,7 +98,7 @@ const Unfarm: FC<Props> = ({ name, symbol, stake }) => {
                     <TextInput
                       value={unfarmInput}
                       onChange={handleUnfarmInputChange}
-                      type="text"
+                      type="number"
                       placeholder={"0 "}
                       icon={
                         <Box pad="xsmall" direction="row" align="center" gap="small">

--- a/packages/app/src/components/faucet/index.tsx
+++ b/packages/app/src/components/faucet/index.tsx
@@ -7,11 +7,11 @@ import { LoadingButtonContent } from "components/LoadingButtonContent";
 import { isPendingTransaction } from "../../utils/transactions";
 type props = {
   symbol: string;
-  name: string;
+  protocolName: string;
 };
 
-const Faucet: FC<props> = ({ symbol, name }) => {
-  const { state: requestTx, send: request } = useContractFunction(contracts[name].faucet, "request", {
+const Faucet: FC<props> = ({ symbol, protocolName }) => {
+  const { state: requestTx, send: request } = useContractFunction(contracts[protocolName].faucet, "request", {
     transactionName: `Requesting ${symbol} from faucet`,
   });
 

--- a/packages/app/src/components/faucet/index.tsx
+++ b/packages/app/src/components/faucet/index.tsx
@@ -30,7 +30,7 @@ const Faucet: FC<props> = ({ symbol, name }) => {
       button1={
         <Button
           primary
-          style={{ width: "250px" }}
+          style={{ width: "100%" }}
           onClick={requestTokens}
           label={
             isPendingTransaction(requestTx) ? <LoadingButtonContent label={`Request ${symbol}`} /> : `Get ${symbol}`
@@ -41,7 +41,7 @@ const Faucet: FC<props> = ({ symbol, name }) => {
       button2={
         <Button
           primary
-          style={{ width: "250px" }}
+          style={{ width: "100%" }}
           href="https://www.rinkebyfaucet.com/"
           target="_blank"
           label="Get ETH"

--- a/packages/app/src/components/nav/index.tsx
+++ b/packages/app/src/components/nav/index.tsx
@@ -8,7 +8,7 @@ import { TenderizeConfig } from "types";
 
 type props = {
   symbol?: string;
-  name?: string;
+  protocolName?: string;
   config: TenderizeConfig;
 };
 const Navbar: FC<props> = (props) => {
@@ -31,14 +31,14 @@ const Navbar: FC<props> = (props) => {
 
   return (
     <Box>
-      {props.symbol != null && props.name != null && <TestnetBanner />}
+      {props.symbol != null && props.protocolName != null && <TestnetBanner />}
       <Header justify="between" pad={{ horizontal: "xlarge", vertical: "xsmall" }}>
         <Link href="/" passHref>
           <Image width="150px" src={"/tenderizeLogo.svg"} alt="header logo" />
         </Link>
-        {props.symbol != null && props.name != null && (
+        {props.symbol != null && props.protocolName != null && (
           <Box direction="row" align="center" gap="medium">
-            <Faucet symbol={props.symbol} name={props.name} />
+            <Faucet symbol={props.symbol} protocolName={props.protocolName} />
             <Nav direction="row">
               <AccountButton config={props.config} />
             </Nav>

--- a/packages/app/src/components/swap/ConfirmSwapModal.tsx
+++ b/packages/app/src/components/swap/ConfirmSwapModal.tsx
@@ -139,7 +139,7 @@ const ConfirmSwapModal: FC<Props> = ({
                         <TextInput
                           readOnly
                           id="formSwapSend"
-                          type="number"
+                          type="text"
                           value={utils.formatEther(tokenAmount || "0")}
                           required={true}
                           style={{ textAlign: "right", padding: "20px 50px" }}

--- a/packages/app/src/components/swap/ConfirmSwapModal.tsx
+++ b/packages/app/src/components/swap/ConfirmSwapModal.tsx
@@ -125,7 +125,7 @@ const ConfirmSwapModal: FC<Props> = ({
               icon={<FormClose />}
               onClick={onDismiss}
             />
-            <CardHeader justify="center" pad={{ bottom: "small" }}>
+            <CardHeader justify="center" pad="none">
               <Heading level={2} alignSelf="center">
                 {`Confirm Swap ${tokenSendedSymbol} for ${tokenReceivedSymbol}`}
               </Heading>

--- a/packages/app/src/components/swap/ConfirmSwapModal.tsx
+++ b/packages/app/src/components/swap/ConfirmSwapModal.tsx
@@ -139,7 +139,7 @@ const ConfirmSwapModal: FC<Props> = ({
                         <TextInput
                           readOnly
                           id="formSwapSend"
-                          type="text"
+                          type="number"
                           value={utils.formatEther(tokenAmount || "0")}
                           required={true}
                           style={{ textAlign: "right", padding: "20px 50px" }}

--- a/packages/app/src/components/swap/ConfirmSwapModal.tsx
+++ b/packages/app/src/components/swap/ConfirmSwapModal.tsx
@@ -11,18 +11,20 @@ import {
   Layer,
   Form,
   FormField,
+  Image,
   TextInput,
   Spinner,
   Text,
   Heading,
 } from "grommet";
 
-import { InfoCard } from "@tender/shared/src/index";
 import { useContractFunction } from "@usedapp/core";
 import { TransactionListElement } from "components/transactions";
 import { getDeadline, useSwapWithPermit } from "utils/tenderSwapHooks";
 import { FormClose } from "grommet-icons";
 import { isPendingTransaction } from "utils/transactions";
+import stakers from "data/stakers";
+import { weiToEthWithDecimals } from "utils/amountFormat";
 
 type Props = {
   show: boolean;
@@ -51,6 +53,11 @@ const ConfirmSwapModal: FC<Props> = ({
   usePermit,
   owner,
 }) => {
+  const staker = stakers[protocolName];
+  const symbol = staker.symbol;
+  const bwLogo = `/${staker.bwLogo}`;
+  const bwTenderLogo = `/${staker.bwTenderLogo}`;
+
   const [confirmStatus, setConfirmStatus] = useState<"None" | "Waiting" | "Submitted" | "Success">("None");
 
   // reset to initial state
@@ -106,7 +113,12 @@ const ConfirmSwapModal: FC<Props> = ({
           }}
           onClickOutside={() => confirmStatus !== "Submitted" && onDismiss()}
         >
-          <Card flex={false} style={{ position: "relative" }} pad="medium">
+          <Card
+            flex={false}
+            pad={{ vertical: "medium", horizontal: "xlarge" }}
+            width="large"
+            style={{ position: "relative" }}
+          >
             <Button
               style={{ position: "absolute", top: 10, right: 10 }}
               plain
@@ -118,11 +130,11 @@ const ConfirmSwapModal: FC<Props> = ({
                 {`Confirm Swap ${tokenSendedSymbol} for ${tokenReceivedSymbol}`}
               </Heading>
             </CardHeader>
-            <CardBody justify="center" align="center">
-              {confirmStatus === "None" && (
-                <>
-                  <Form>
-                    <Box justify="around" align="center">
+            <CardBody>
+              <Box pad={{ top: "medium", horizontal: "large" }} align="center">
+                {confirmStatus === "None" && (
+                  <Form style={{ width: "100%" }}>
+                    <Box gap="medium">
                       <FormField label={`Send ${tokenSendedSymbol}`}>
                         <TextInput
                           readOnly
@@ -130,6 +142,13 @@ const ConfirmSwapModal: FC<Props> = ({
                           type="number"
                           value={utils.formatEther(tokenAmount || "0")}
                           required={true}
+                          style={{ textAlign: "right", padding: "20px 50px" }}
+                          icon={
+                            <Box pad="xsmall" direction="row" align="center" gap="small">
+                              <Image height="35" src={tokenSendedSymbol === symbol ? bwLogo : bwTenderLogo} />
+                              <Text>{tokenSendedSymbol}</Text>
+                            </Box>
+                          }
                         />
                       </FormField>
                       <FormField label={`Receive ${tokenReceivedSymbol}`}>
@@ -138,67 +157,76 @@ const ConfirmSwapModal: FC<Props> = ({
                           id="formSwapReceive"
                           placeholder={"0"}
                           value={utils.formatEther(tokenReceiveAmount || "0")}
+                          style={{ textAlign: "right", padding: "20px 50px" }}
+                          icon={
+                            <Box pad="xsmall" direction="row" align="center" gap="small">
+                              <Image height="35" src={tokenSendedSymbol === symbol ? bwLogo : bwTenderLogo} />
+                              <Text>{tokenReceivedSymbol}</Text>
+                            </Box>
+                          }
                         />
                       </FormField>
                     </Box>
+                    <Box pad={{ vertical: "medium" }} justify="center" align="center">
+                      <Text>Price: {`${weiToEthWithDecimals(tokenSpotPrice, 5)} ${tokenSendedSymbol}`} </Text>
+                    </Box>
                   </Form>
-                  <Box>
-                    <InfoCard title="Price" text={`${utils.formatEther(tokenSpotPrice)} ${tokenSendedSymbol}`} />
+                )}
+                {confirmStatus === "Waiting" && (
+                  <Box justify="center" align="center" gap="medium">
+                    <Spinner size="medium" color="brand" />
+                    <Text size="xlarge" textAlign="center">
+                      Waiting For Confirmation...
+                    </Text>
+                    <Text>
+                      Swapping {utils.formatEther(tokenAmount || "0")} {tokenSendedSymbol} for{" "}
+                      {utils.formatEther(tokenReceiveAmount || "0")} {tokenReceivedSymbol}
+                    </Text>
+                    <Text>Confirm this transaction in your wallet.</Text>
                   </Box>
-                </>
-              )}
-              {confirmStatus === "Waiting" && (
-                <Box justify="center" align="center" gap="medium">
-                  <Spinner size="medium" color="brand" />
-                  <Text size="xlarge" textAlign="center">
-                    Waiting For Confirmation...
-                  </Text>
-                  <Text>
-                    Swapping {utils.formatEther(tokenAmount || "0")} {tokenSendedSymbol} for{" "}
-                    {utils.formatEther(tokenReceiveAmount || "0")} {tokenReceivedSymbol}
-                  </Text>
-                  <Text>Confirm this transaction in your wallet.</Text>
-                </Box>
-              )}
-              {confirmStatus === "Submitted" && (
-                <Box justify="center" align="center" gap="medium">
-                  <Text size="large" textAlign="center">
-                    Transaction is being processed...
-                  </Text>
-                  <TransactionListElement
-                    transaction={swapTx.transaction}
-                    title={`Swap ${tokenSendedSymbol} for ${tokenReceivedSymbol}`}
-                    icon={undefined}
-                  />
-                  {swapTx.status !== "Success" && <Spinner size="medium" color="brand" />}
-                  <Button primary onClick={onDismiss} label="Dismiss" />
-                </Box>
-              )}
-              {confirmStatus === "Success" && (
-                <Box justify="center" align="center" gap="medium">
-                  <Text size="large" textAlign="center">
-                    Transaction was successful!
-                  </Text>
-                  <TransactionListElement
-                    transaction={swapTx.transaction}
-                    title={`Swap ${tokenSendedSymbol} for ${tokenReceivedSymbol}`}
-                    icon={undefined}
-                  />
-                  {swapTx.status !== "Success" && <Spinner size="medium" color="brand" />}
-                  <Button primary onClick={onDismiss} label="Done" />
-                </Box>
-              )}
+                )}
+                {confirmStatus === "Submitted" && (
+                  <Box justify="center" align="center" gap="medium">
+                    <Text size="large" textAlign="center">
+                      Transaction is being processed...
+                    </Text>
+                    <TransactionListElement
+                      transaction={swapTx.transaction}
+                      title={`Swap ${tokenSendedSymbol} for ${tokenReceivedSymbol}`}
+                      icon={undefined}
+                    />
+                    {swapTx.status !== "Success" && <Spinner size="medium" color="brand" />}
+                    <Button primary onClick={onDismiss} label="Dismiss" />
+                  </Box>
+                )}
+                {confirmStatus === "Success" && (
+                  <Box justify="center" align="center" gap="medium">
+                    <Text size="large" textAlign="center">
+                      Transaction was successful!
+                    </Text>
+                    <TransactionListElement
+                      transaction={swapTx.transaction}
+                      title={`Swap ${tokenSendedSymbol} for ${tokenReceivedSymbol}`}
+                      icon={undefined}
+                    />
+                    {swapTx.status !== "Success" && <Spinner size="medium" color="brand" />}
+                    <Button primary onClick={onDismiss} label="Done" />
+                  </Box>
+                )}
+              </Box>
             </CardBody>
             {confirmStatus === "None" && (
-              <CardFooter justify="center" pad={{ top: "small" }}>
-                <Button
-                  primary
-                  onClick={(e) => {
-                    handlePressTrade(e);
-                    setConfirmStatus("Waiting");
-                  }}
-                  label="Confirm Swap"
-                />
+              <CardFooter justify="center" pad={{ vertical: "medium" }}>
+                <Box style={{ width: "100%" }} pad={{ horizontal: "large" }} justify="center" gap="small">
+                  <Button
+                    primary
+                    onClick={(e) => {
+                      handlePressTrade(e);
+                      setConfirmStatus("Waiting");
+                    }}
+                    label="Confirm Swap"
+                  />
+                </Box>
               </CardFooter>
             )}
           </Card>

--- a/packages/app/src/components/swap/Dialog.tsx
+++ b/packages/app/src/components/swap/Dialog.tsx
@@ -38,7 +38,7 @@ const Dialog: FC<props> = (props) => {
               icon={<FormClose />}
               onClick={handleClose}
             />
-            <CardHeader justify="center">
+            <CardHeader justify="center" pad="none">
               <Heading level={2} alignSelf="center">
                 {props.title}
               </Heading>

--- a/packages/app/src/components/swap/exit.tsx
+++ b/packages/app/src/components/swap/exit.tsx
@@ -132,15 +132,13 @@ const ExitPool: FC<Props> = ({ protocolName, symbol, lpTokenBalance }) => {
       <Button secondary onClick={handleShow} label="Exit Pool" />
 
       {show && (
-        <Layer
-          style={{ overflow: "auto" }}
-          animation="fadeIn"
-          margin={{ top: "xlarge" }}
-          position="top"
-          onEsc={handleClose}
-          onClickOutside={handleClose}
-        >
-          <Card flex={false} pad="medium" width="large" style={{ position: "relative" }}>
+        <Layer style={{ overflow: "auto" }} animation="fadeIn" onEsc={handleClose} onClickOutside={handleClose}>
+          <Card
+            flex={false}
+            pad={{ vertical: "medium", horizontal: "xlarge" }}
+            width="large"
+            style={{ position: "relative" }}
+          >
             <Button
               style={{ position: "absolute", top: 10, right: 10 }}
               plain
@@ -161,8 +159,8 @@ const ExitPool: FC<Props> = ({ protocolName, symbol, lpTokenBalance }) => {
                     </Box>
                   }
                 >
-                  <Box pad={{ top: "medium" }} align="center">
-                    <Form validate="change">
+                  <Box pad={{ top: "medium", horizontal: "large" }} align="center">
+                    <Form validate="change" style={{ width: "100%" }}>
                       <Box gap="medium">
                         <LPTokensToRemoveInputField
                           lpTokenBalance={lpTokenBalance}
@@ -215,8 +213,8 @@ const ExitPool: FC<Props> = ({ protocolName, symbol, lpTokenBalance }) => {
                     </Box>
                   }
                 >
-                  <Box pad={{ top: "medium" }} align="center">
-                    <Form>
+                  <Box pad={{ top: "medium", horizontal: "large" }} align="center">
+                    <Form style={{ width: "100%" }}>
                       <Box gap="medium">
                         <LPTokensToRemoveInputField
                           lpTokenBalance={lpTokenBalance}
@@ -226,45 +224,39 @@ const ExitPool: FC<Props> = ({ protocolName, symbol, lpTokenBalance }) => {
                         />
                         <Box>
                           <FormField label="Select Token To Receive" controlId="selectTokenReceive">
-                            <Box width="medium">
-                              <Select
-                                value={
-                                  <Box direction="row" gap="small" align="center" pad="7px">
-                                    <img
-                                      height={30}
-                                      width={30}
-                                      src={selectedToken === symbol ? `/${staker.bwLogo}` : `/${staker.bwTenderLogo}`}
-                                      alt="token logo"
-                                    />
-                                    {selectedToken}
-                                  </Box>
-                                }
-                                options={[
-                                  <Box direction="row" gap="small" align="center">
-                                    <img
-                                      height={30}
-                                      width={30}
-                                      src={selectedToken === symbol ? `/${staker.bwTenderLogo}` : `/${staker.bwLogo}`}
-                                      alt="token logo"
-                                    />
-                                    {selectedToken === symbol ? `t${symbol}` : symbol}
-                                  </Box>,
-                                ]}
-                                onChange={() => setSelectedToken(selectedToken === symbol ? `t${symbol}` : symbol)}
-                              />
-                            </Box>
-                          </FormField>
-                          <FormField label="You will receive">
-                            <Box direction="row" align="center" width="medium" gap="small">
-                              <Text>{selectedToken}</Text>
-                              <TextInput
-                                readOnly
-                                disabled
-                                id="exitMultiReceive"
-                                placeholder={"0"}
-                                value={utils.formatEther(singleOut)}
-                              />
-                            </Box>
+                            <Select
+                              value={
+                                <TextInput
+                                  disabled
+                                  readOnly
+                                  value={utils.formatEther(singleOut)}
+                                  placeholder={"0"}
+                                  type="text"
+                                  style={{ textAlign: "right", padding: "20px 50px", border: "none" }}
+                                  icon={
+                                    <Box pad="xsmall" direction="row" align="center" gap="small">
+                                      <Image
+                                        height="35"
+                                        src={selectedToken === symbol ? `/${staker.bwTenderLogo}` : `/${staker.bwLogo}`}
+                                      />
+                                      <Text>t{symbol}</Text>
+                                    </Box>
+                                  }
+                                />
+                              }
+                              options={[
+                                <Box direction="row" gap="small" align="center">
+                                  <img
+                                    height={30}
+                                    width={30}
+                                    src={selectedToken === symbol ? `/${staker.bwTenderLogo}` : `/${staker.bwLogo}`}
+                                    alt="token logo"
+                                  />
+                                  {selectedToken === symbol ? `t${symbol}` : symbol}
+                                </Box>,
+                              ]}
+                              onChange={() => setSelectedToken(selectedToken === symbol ? `t${symbol}` : symbol)}
+                            />
                           </FormField>
                         </Box>
                       </Box>
@@ -273,11 +265,10 @@ const ExitPool: FC<Props> = ({ protocolName, symbol, lpTokenBalance }) => {
                 </Tab>
               </Tabs>
             </CardBody>
-            <CardFooter align="center" justify="center" pad={{ top: "medium" }}>
-              <Box pad={{ horizontal: "large" }} justify="center" gap="small">
+            <CardFooter align="center" justify="center" pad={{ vertical: "medium" }}>
+              <Box style={{ width: "100%" }} pad={{ horizontal: "large" }} justify="center" gap="small">
                 <Button
                   primary
-                  style={{ width: 501 }}
                   onClick={handleRemoveLiquidity}
                   disabled={
                     !hasValue(lpSharesInputSingle || lpSharesInputMulti) ||
@@ -332,6 +323,7 @@ const LPTokensToRemoveInputField: FC<{
           onChange={handleLpSharesInputChange}
           type="text"
           placeholder={"0 " + symbolFull}
+          style={{ textAlign: "right", padding: "20px 50px" }}
         />
       </Box>
       <AmountInputFooter

--- a/packages/app/src/components/swap/exit.tsx
+++ b/packages/app/src/components/swap/exit.tsx
@@ -145,7 +145,7 @@ const ExitPool: FC<Props> = ({ protocolName, symbol, lpTokenBalance }) => {
               icon={<FormClose />}
               onClick={handleClose}
             />
-            <CardHeader justify="center" pad={{ bottom: "small" }}>
+            <CardHeader justify="center" pad="none">
               <Heading level={2} alignSelf="center">
                 {`Exit tender${symbol}/${symbol}`}
               </Heading>

--- a/packages/app/src/components/swap/exit.tsx
+++ b/packages/app/src/components/swap/exit.tsx
@@ -231,7 +231,7 @@ const ExitPool: FC<Props> = ({ protocolName, symbol, lpTokenBalance }) => {
                                   readOnly
                                   value={utils.formatEther(singleOut)}
                                   placeholder={"0"}
-                                  type="text"
+                                  type="number"
                                   style={{ textAlign: "right", padding: "20px 50px", border: "none" }}
                                   icon={
                                     <Box pad="xsmall" direction="row" align="center" gap="small">
@@ -321,7 +321,7 @@ const LPTokensToRemoveInputField: FC<{
         <TextInput
           value={lpSharesInput}
           onChange={handleLpSharesInputChange}
-          type="text"
+          type="number"
           placeholder={"0 " + symbolFull}
           style={{ textAlign: "right", padding: "20px 50px" }}
         />

--- a/packages/app/src/components/swap/index.tsx
+++ b/packages/app/src/components/swap/index.tsx
@@ -7,18 +7,18 @@ import ExitPool from "./exit";
 import { Box, Text } from "grommet";
 
 type Props = {
-  name: string;
+  protocolName: string;
   symbol: string;
   tokenBalance: BigNumberish;
   tenderTokenBalance: BigNumberish;
   lpTokenBalance: BigNumber;
 };
 
-const LiquidityPool: FC<Props> = ({ name, symbol, tokenBalance, tenderTokenBalance, lpTokenBalance }) => {
+const LiquidityPool: FC<Props> = ({ protocolName, symbol, tokenBalance, tenderTokenBalance, lpTokenBalance }) => {
   return (
     <Box justify="start" align="center">
       <Swap
-        protocolName={name}
+        protocolName={protocolName}
         tokenSymbol={symbol}
         tokenBalance={tokenBalance}
         tenderTokenBalance={tenderTokenBalance}
@@ -34,8 +34,13 @@ const LiquidityPool: FC<Props> = ({ name, symbol, tokenBalance, tenderTokenBalan
       >
         <Text>Provide Liquidity</Text>
         <Box direction="row" gap="large" justify="center" align="center">
-          <JoinPool name={name} symbol={symbol} tokenBalance={tokenBalance} tenderTokenBalance={tenderTokenBalance} />
-          <ExitPool protocolName={name} symbol={symbol} lpTokenBalance={lpTokenBalance} />
+          <JoinPool
+            protocolName={protocolName}
+            symbol={symbol}
+            tokenBalance={tokenBalance}
+            tenderTokenBalance={tenderTokenBalance}
+          />
+          <ExitPool protocolName={protocolName} symbol={symbol} lpTokenBalance={lpTokenBalance} />
         </Box>
       </Box>
     </Box>

--- a/packages/app/src/components/swap/join.tsx
+++ b/packages/app/src/components/swap/join.tsx
@@ -109,15 +109,13 @@ const JoinPool: FC<Props> = ({ name, symbol, tokenBalance, tenderTokenBalance })
     <Box pad={{ horizontal: "large", top: "small" }}>
       <Button primary onClick={handleShow} label="Join Pool" />
       {show && (
-        <Layer
-          style={{ overflow: "auto" }}
-          animation="fadeIn"
-          margin={{ top: "xlarge" }}
-          position="top"
-          onEsc={handleClose}
-          onClickOutside={handleClose}
-        >
-          <Card flex={false} pad="medium" width="large" style={{ position: "relative" }}>
+        <Layer style={{ overflow: "auto" }} animation="fadeIn" onEsc={handleClose} onClickOutside={handleClose}>
+          <Card
+            flex={false}
+            pad={{ vertical: "medium", horizontal: "xlarge" }}
+            width="large"
+            style={{ position: "relative" }}
+          >
             <Button
               style={{ position: "absolute", top: 10, right: 10 }}
               plain
@@ -130,29 +128,27 @@ const JoinPool: FC<Props> = ({ name, symbol, tokenBalance, tenderTokenBalance })
               </Heading>
             </CardHeader>
             <CardBody>
-              <Box pad={{ top: "medium" }} align="center">
-                <Form validate="change">
+              <Box pad={{ top: "medium", horizontal: "large" }} align="center">
+                <Form validate="change" style={{ width: "100%" }}>
                   <Box gap="medium">
                     <FormField
                       label={`${symbol} Amount`}
                       name="tokenInput"
                       validate={[validateIsPositive(tokenInput), validateIsLargerThanMax(tokenInput, tokenBalance)]}
                     >
-                      <Box width="medium">
-                        <TextInput
-                          value={tokenInput}
-                          onChange={handleTokenInputChange}
-                          type="text"
-                          icon={
-                            <Box pad="xsmall" direction="row" align="center" gap="small">
-                              <Image height="35" src={bwLogo} />
-                              <Text>{symbol}</Text>
-                            </Box>
-                          }
-                          style={{ textAlign: "right", padding: "20px 50px" }}
-                          placeholder={"0"}
-                        />
-                      </Box>
+                      <TextInput
+                        value={tokenInput}
+                        onChange={handleTokenInputChange}
+                        type="text"
+                        icon={
+                          <Box pad="xsmall" direction="row" align="center" gap="small">
+                            <Image height="35" src={bwLogo} />
+                            <Text>{symbol}</Text>
+                          </Box>
+                        }
+                        style={{ textAlign: "right", padding: "20px 50px" }}
+                        placeholder={"0"}
+                      />
                       <AmountInputFooter
                         label={`Balance: ${utils.formatEther(tokenBalance?.toString() || "0")} ${symbol}`}
                         onClick={maxTokenDeposit}
@@ -166,41 +162,45 @@ const JoinPool: FC<Props> = ({ name, symbol, tokenBalance, tenderTokenBalance })
                         validateIsLargerThanMax(tenderInput, tenderTokenBalance),
                       ]}
                     >
-                      <Box width="medium">
-                        <TextInput
-                          value={tenderInput}
-                          onChange={handleTenderInputChange}
-                          type="text"
-                          icon={
-                            <Box pad="xsmall" direction="row" align="center" gap="small">
-                              <Image height="35" src={bwTenderLogo} />
-                              <Text>t{symbol}</Text>
-                            </Box>
-                          }
-                          style={{ textAlign: "right", padding: "20px 50px" }}
-                          placeholder={"0"}
-                        />
-                      </Box>
+                      <TextInput
+                        value={tenderInput}
+                        onChange={handleTenderInputChange}
+                        type="text"
+                        icon={
+                          <Box pad="xsmall" direction="row" align="center" gap="small">
+                            <Image height="35" src={bwTenderLogo} />
+                            <Text>t{symbol}</Text>
+                          </Box>
+                        }
+                        style={{ textAlign: "right", padding: "20px 50px" }}
+                        placeholder={"0"}
+                      />
                       <AmountInputFooter
                         label={`Balance: ${utils.formatEther(tenderTokenBalance?.toString() || "0")} t${symbol}`}
                         onClick={maxTenderTokenDeposit}
                       />
                     </FormField>
+                    <FormField label={`Amount of ${lpTokenSymbol} to receive`}>
+                      <TextInput
+                        readOnly
+                        disabled
+                        value={weiToEthWithDecimals(lpTokenAmount, 6)}
+                        placeholder={"0"}
+                        type="text"
+                        style={{ textAlign: "right", padding: "20px 50px" }}
+                        icon={
+                          <Box pad="xsmall" direction="row" align="center" gap="small">
+                            <Text>{lpTokenSymbol}</Text>
+                          </Box>
+                        }
+                      />
+                    </FormField>
                   </Box>
                 </Form>
-                <Text>
-                  {lpTokenAmount && !lpTokenAmount.isZero() ? (
-                    <>
-                      You will receive {weiToEthWithDecimals(lpTokenAmount, 6)} {lpTokenSymbol}
-                    </>
-                  ) : (
-                    <>&nbsp;</>
-                  )}
-                </Text>
               </Box>
             </CardBody>
-            <CardFooter align="center" justify="center" pad={{ top: "medium" }}>
-              <Box justify="center" gap="small">
+            <CardFooter align="center" justify="center" pad={{ vertical: "medium" }}>
+              <Box style={{ width: "100%" }} pad={{ horizontal: "large" }} justify="center" gap="small">
                 {
                   // TODO this is a workaround, report gap bug to grommet (applying gap for undefined or empty elements)
                   !isTokenApproved && (
@@ -214,7 +214,6 @@ const JoinPool: FC<Props> = ({ name, symbol, tokenBalance, tenderTokenBalance })
                 }
                 <Button
                   primary
-                  style={{ width: 467 }}
                   onClick={handleAddLiquidity}
                   disabled={isButtonDisabled()}
                   label={

--- a/packages/app/src/components/swap/join.tsx
+++ b/packages/app/src/components/swap/join.tsx
@@ -29,14 +29,14 @@ import { useEthers } from "@usedapp/core";
 import { FormClose } from "grommet-icons";
 
 type Props = {
-  name: string;
+  protocolName: string;
   symbol: string;
   tokenBalance: BigNumberish;
   tenderTokenBalance: BigNumberish;
 };
 
-const JoinPool: FC<Props> = ({ name, symbol, tokenBalance, tenderTokenBalance }) => {
-  const staker = stakers[name];
+const JoinPool: FC<Props> = ({ protocolName, symbol, tokenBalance, tenderTokenBalance }) => {
+  const staker = stakers[protocolName];
   const bwLogo = `/${staker.bwLogo}`;
   const bwTenderLogo = `/${staker.bwTenderLogo}`;
   const [show, setShow] = useState(false);
@@ -71,11 +71,16 @@ const JoinPool: FC<Props> = ({ name, symbol, tokenBalance, tenderTokenBalance })
     setTenderInput(utils.formatEther(tenderTokenBalance || "0"));
   };
 
-  const isTokenApproved = useIsTokenApproved(addresses[name].token, account, addresses[name].tenderSwap, tokenInput);
-  const isTenderApproved = useIsTokenApproved(
-    addresses[name].tenderToken,
+  const isTokenApproved = useIsTokenApproved(
+    addresses[protocolName].token,
     account,
-    addresses[name].tenderSwap,
+    addresses[protocolName].tenderSwap,
+    tokenInput
+  );
+  const isTenderApproved = useIsTokenApproved(
+    addresses[protocolName].tenderToken,
+    account,
+    addresses[protocolName].tenderSwap,
     tenderInput
   );
 
@@ -84,16 +89,16 @@ const JoinPool: FC<Props> = ({ name, symbol, tokenBalance, tenderTokenBalance })
   };
 
   const { addLiquidity, tx: addLiquidityTx } = useAddLiquidity(
-    addresses[name].tenderToken,
-    name,
+    addresses[protocolName].tenderToken,
+    protocolName,
     account,
-    addresses[name].tenderSwap,
+    addresses[protocolName].tenderSwap,
     symbol,
     isTenderApproved
   );
 
   const lpTokenAmount = useCalculateLpTokenAmount(
-    addresses[name].tenderSwap,
+    addresses[protocolName].tenderSwap,
     [utils.parseEther(tenderInput || "0"), utils.parseEther(tokenInput || "0")],
     true
   );
@@ -133,7 +138,7 @@ const JoinPool: FC<Props> = ({ name, symbol, tokenBalance, tenderTokenBalance })
                   <Box gap="medium">
                     <FormField
                       label={`${symbol} Amount`}
-                      name="tokenInput"
+                      protocolName="tokenInput"
                       validate={[validateIsPositive(tokenInput), validateIsLargerThanMax(tokenInput, tokenBalance)]}
                     >
                       <TextInput
@@ -156,7 +161,7 @@ const JoinPool: FC<Props> = ({ name, symbol, tokenBalance, tenderTokenBalance })
                     </FormField>
                     <FormField
                       label={`t${symbol} Amount`}
-                      name="tenderInput"
+                      protocolName="tenderInput"
                       validate={[
                         validateIsPositive(tenderInput),
                         validateIsLargerThanMax(tenderInput, tenderTokenBalance),
@@ -206,8 +211,8 @@ const JoinPool: FC<Props> = ({ name, symbol, tokenBalance, tenderTokenBalance })
                   !isTokenApproved && (
                     <ApproveToken
                       symbol={symbol}
-                      spender={addresses[name].tenderSwap}
-                      token={contracts[name].token}
+                      spender={addresses[protocolName].tenderSwap}
+                      token={contracts[protocolName].token}
                       show={!isTokenApproved}
                     />
                   )

--- a/packages/app/src/components/swap/join.tsx
+++ b/packages/app/src/components/swap/join.tsx
@@ -122,7 +122,7 @@ const JoinPool: FC<Props> = ({ name, symbol, tokenBalance, tenderTokenBalance })
               icon={<FormClose />}
               onClick={handleClose}
             />
-            <CardHeader justify="center" pad={{ bottom: "small" }}>
+            <CardHeader justify="center" pad="none">
               <Heading level={2} alignSelf="center">
                 {`Join tender${symbol}/${symbol}`}
               </Heading>

--- a/packages/app/src/components/swap/join.tsx
+++ b/packages/app/src/components/swap/join.tsx
@@ -139,7 +139,7 @@ const JoinPool: FC<Props> = ({ name, symbol, tokenBalance, tenderTokenBalance })
                       <TextInput
                         value={tokenInput}
                         onChange={handleTokenInputChange}
-                        type="text"
+                        type="number"
                         icon={
                           <Box pad="xsmall" direction="row" align="center" gap="small">
                             <Image height="35" src={bwLogo} />
@@ -165,7 +165,7 @@ const JoinPool: FC<Props> = ({ name, symbol, tokenBalance, tenderTokenBalance })
                       <TextInput
                         value={tenderInput}
                         onChange={handleTenderInputChange}
-                        type="text"
+                        type="number"
                         icon={
                           <Box pad="xsmall" direction="row" align="center" gap="small">
                             <Image height="35" src={bwTenderLogo} />
@@ -186,7 +186,7 @@ const JoinPool: FC<Props> = ({ name, symbol, tokenBalance, tenderTokenBalance })
                         disabled
                         value={weiToEthWithDecimals(lpTokenAmount, 6)}
                         placeholder={"0"}
-                        type="text"
+                        type="number"
                         style={{ textAlign: "right", padding: "20px 50px" }}
                         icon={
                           <Box pad="xsmall" direction="row" align="center" gap="small">

--- a/packages/app/src/components/swap/swap.tsx
+++ b/packages/app/src/components/swap/swap.tsx
@@ -86,7 +86,7 @@ const Swap: FC<Props> = ({ tokenSymbol, tokenBalance, tenderTokenBalance, protoc
                 <TextInput
                   ref={sendInputRef}
                   id="formSwapSend"
-                  type="text"
+                  type="number"
                   icon={
                     <Box pad="xsmall" direction="row" align="center" gap="small">
                       <Image height="35" src={sendTokenLogo} />
@@ -138,7 +138,7 @@ const Swap: FC<Props> = ({ tokenSymbol, tokenBalance, tenderTokenBalance, protoc
                 <Box width="medium">
                   <TextInput
                     id="formSwapReceive"
-                    type="text"
+                    type="number"
                     placeholder={"0"}
                     icon={
                       <Box pad="xsmall" direction="row" align="center" gap="small">

--- a/packages/app/src/components/swap/swap.tsx
+++ b/packages/app/src/components/swap/swap.tsx
@@ -86,7 +86,7 @@ const Swap: FC<Props> = ({ tokenSymbol, tokenBalance, tenderTokenBalance, protoc
                 <TextInput
                   ref={sendInputRef}
                   id="formSwapSend"
-                  type="number"
+                  type="text"
                   icon={
                     <Box pad="xsmall" direction="row" align="center" gap="small">
                       <Image height="35" src={sendTokenLogo} />
@@ -138,8 +138,8 @@ const Swap: FC<Props> = ({ tokenSymbol, tokenBalance, tenderTokenBalance, protoc
                 <Box width="medium">
                   <TextInput
                     id="formSwapReceive"
-                    type="number"
-                    placeholder={`0 ${tokenReceivedSymbol}`}
+                    type="text"
+                    placeholder={"0"}
                     icon={
                       <Box pad="xsmall" direction="row" align="center" gap="small">
                         <Image height="35" src={tokenReceivedLogo} />

--- a/packages/app/src/pages/index.css
+++ b/packages/app/src/pages/index.css
@@ -7,3 +7,7 @@ input[type="number"]::-webkit-outer-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
+
+input[type="number"] {
+  appearance: textfield;
+}

--- a/packages/app/src/pages/stakers/[slug].tsx
+++ b/packages/app/src/pages/stakers/[slug].tsx
@@ -21,16 +21,16 @@ import { TenderizeConfig } from "types";
 
 const Token: FC<{ config: TenderizeConfig }> = (props) => {
   const router = useRouter();
-  const name = router.query.slug as string;
-  const info = stakers[name];
+  const protocolName = router.query.slug as string;
+  const info = stakers[protocolName];
   const [tabIndex, setTabIndex] = useState(1);
 
   let { account } = useEthers();
   account = account ?? constants.AddressZero;
   // TODO: USE MULTICALL FOR THESE
-  const tokenBalance = useTokenBalance(addresses[name].token, account) || constants.Zero;
-  const tenderBalance = useTokenBalance(addresses[name].tenderToken, account) || constants.Zero;
-  const lpTokenBalance = useTokenBalance(addresses[name].lpToken, account) || constants.Zero;
+  const tokenBalance = useTokenBalance(addresses[protocolName].token, account) || constants.Zero;
+  const tenderBalance = useTokenBalance(addresses[protocolName].tenderToken, account) || constants.Zero;
+  const lpTokenBalance = useTokenBalance(addresses[protocolName].lpToken, account) || constants.Zero;
 
   const onActive = useCallback((nextIndex: number) => {
     if (nextIndex === 0) {
@@ -43,7 +43,7 @@ const Token: FC<{ config: TenderizeConfig }> = (props) => {
   return (
     <Box>
       <NotificationsList />
-      <Navbar symbol={info.symbol} name={name} config={props.config} />
+      <Navbar symbol={info.symbol} protocolName={protocolName} config={props.config} />
       <Box width="100vw" align="center" alignSelf="start">
         <TenderBox
           margin={{
@@ -75,7 +75,7 @@ const Token: FC<{ config: TenderizeConfig }> = (props) => {
                 }}
               >
                 <Deposit
-                  name={name}
+                  protocolName={protocolName}
                   symbol={info.symbol}
                   logo={info.bwLogo}
                   tokenBalance={tokenBalance}
@@ -98,7 +98,7 @@ const Token: FC<{ config: TenderizeConfig }> = (props) => {
             >
               <Box round={{ corner: "bottom" }} border="top" pad="medium">
                 <LiquidityPool
-                  name={name}
+                  protocolName={protocolName}
                   symbol={info.symbol}
                   tokenBalance={tokenBalance}
                   tenderTokenBalance={tenderBalance}
@@ -120,7 +120,12 @@ const Token: FC<{ config: TenderizeConfig }> = (props) => {
               }
             >
               <Box round={{ corner: "bottom" }} border="top" pad="medium">
-                <Farm name={name} symbol={info.symbol} account={account} lpTokenBalance={lpTokenBalance} />
+                <Farm
+                  protocolName={protocolName}
+                  symbol={info.symbol}
+                  account={account}
+                  lpTokenBalance={lpTokenBalance}
+                />
               </Box>
             </Tab>
           </Tabs>

--- a/packages/app/src/utils/forceChainIdOnCall.tsx
+++ b/packages/app/src/utils/forceChainIdOnCall.tsx
@@ -23,7 +23,7 @@ export const useForceRinkebyFunction = <TFunc extends (...args: any[]) => any>(
     return (
       <Layer style={{ overflow: "auto" }} animation="fadeIn" onEsc={onClose} onClickOutside={onClose}>
         <Card flex={false} pad="medium" width="large">
-          <CardHeader justify="center" pad={{ bottom: "small" }}>
+          <CardHeader justify="center" pad="none">
             <Heading level={2} alignSelf="center">
               {"Please switch to rinkeby to use Tenderize"}
             </Heading>


### PR DESCRIPTION
- Fix modal/dialog sizes to be uniform
- Fix button lengths to fill container
- In exit pool tokens show LP tokens to receive in selector component instead of a separate component
- Add token icons where we didn't have them
- Use text input fields instead of number for swap (like we do elsewhere)