### PR TITLE
Permit for deposit, swap and addLiquidity if underlying token supports it

### DIFF
--- a/packages/app/src/components/account/index.tsx
+++ b/packages/app/src/components/account/index.tsx
@@ -26,7 +26,6 @@ export const AccountButton: FC<{ config: TenderizeConfig }> = ({ config }) => {
   };
 
   const etherBal = useEtherBalance(account);
-
   const supportedChainIds = Object.keys(config.chainUrlMapping).map((i) => parseInt(i, 10));
 
   return (

--- a/packages/app/src/components/account/index.tsx
+++ b/packages/app/src/components/account/index.tsx
@@ -26,6 +26,7 @@ export const AccountButton: FC<{ config: TenderizeConfig }> = ({ config }) => {
   };
 
   const etherBal = useEtherBalance(account);
+
   const supportedChainIds = Object.keys(config.chainUrlMapping).map((i) => parseInt(i, 10));
 
   return (

--- a/packages/app/src/components/farm/index.tsx
+++ b/packages/app/src/components/farm/index.tsx
@@ -1,6 +1,6 @@
 import { FC, useEffect } from "react";
 import { addresses, contracts } from "@tender/contracts";
-import { BigNumberish } from "ethers";
+import { BigNumberish, constants } from "ethers";
 import { useContractCall } from "@usedapp/core";
 import { useQuery } from "@apollo/client";
 import { Box, Text } from "grommet";
@@ -59,16 +59,14 @@ const TenderFarm: FC<Props> = ({ protocolName, symbol, account, lpTokenBalance }
             text={`${weiToEthWithDecimals(stakeOf?.toString() || "0", 3)} ${symbolFull}`}
             align="center"
           />
-          {!isCorrectChain ? (
-            <></>
-          ) : (
-            <>
+          {isCorrectChain && (
+            <Box direction="column" gap="small" align="center">
               <Farm protocolName={protocolName} symbol={symbolFull} tokenBalance={lpTokenBalance || "0"} />
               <Text size="small">{`Balance: ${weiToEthWithDecimals(
                 lpTokenBalance?.toString() || "0",
                 3
               )} ${symbolFull}`}</Text>
-            </>
+            </Box>
           )}
         </Box>
         <Box direction="column" gap="large" align="center">
@@ -77,7 +75,7 @@ const TenderFarm: FC<Props> = ({ protocolName, symbol, account, lpTokenBalance }
             text={`${weiToEthWithDecimals(availableRewards?.toString() || "0", 3)} tender${symbol}`}
             align="center"
           />
-          {!isCorrectChain ? <></> : <Unfarm protocolName={protocolName} symbol={symbolFull} stake={stakeOf || "0"} />}
+          {isCorrectChain && <Unfarm protocolName={protocolName} symbol={symbolFull} stake={stakeOf || "0"} />}
         </Box>
         <Box direction="column" gap="large" align="center">
           <InfoCard
@@ -88,9 +86,7 @@ const TenderFarm: FC<Props> = ({ protocolName, symbol, account, lpTokenBalance }
               3
             )} tender${symbol}`}
           />
-          {!isCorrectChain ? (
-            <></>
-          ) : (
+          {isCorrectChain && (
             <Harvest
               protocolName={protocolName}
               symbol={`tender${symbol}`}
@@ -99,15 +95,15 @@ const TenderFarm: FC<Props> = ({ protocolName, symbol, account, lpTokenBalance }
           )}
         </Box>
       </Box>
-      {!isCorrectChain && account ? (
+      {!isCorrectChain && isConnected(account) && (
         <Box justify="center" align="center" pad={{ vertical: "large" }}>
           <SwitchNetwork chainId={requiredChain} protocol={stakers[protocolName].title} />
         </Box>
-      ) : (
-        <></>
       )}
     </Box>
   );
 };
+
+const isConnected = (account: string) => account && account !== constants.AddressZero;
 
 export default TenderFarm;

--- a/packages/app/src/components/swap/index.tsx
+++ b/packages/app/src/components/swap/index.tsx
@@ -32,11 +32,12 @@ const LiquidityPool: FC<Props> = ({ protocolName, symbol, tokenBalance, tenderTo
         tenderTokenBalance={tenderTokenBalance}
         disabled={!isCorrectChain}
       />
-      {!isCorrectChain && account ? (
+      {!isCorrectChain && account && (
         <Box pad={{ vertical: "large" }}>
           <SwitchNetwork chainId={requiredChain} protocol={stakers[protocolName].title} />
         </Box>
-      ) : (
+      )}
+      {isCorrectChain && (
         <Box
           margin={{ top: "medium" }}
           pad={{ horizontal: "large", vertical: "medium" }}

--- a/packages/app/src/components/swap/join.tsx
+++ b/packages/app/src/components/swap/join.tsx
@@ -42,6 +42,9 @@ const JoinPool: FC<Props> = ({ protocolName, symbol, tokenBalance, tenderTokenBa
   const [show, setShow] = useState(false);
   const { account } = useEthers();
 
+  // whether supported asset (e.g. LPT) has ERC20 permit support
+  const hasPermit = stakers[protocolName].hasPermit;
+
   const handleClose = () => setShow(false);
   const handleShow = () => setShow(true);
 
@@ -85,17 +88,15 @@ const JoinPool: FC<Props> = ({ protocolName, symbol, tokenBalance, tenderTokenBa
   );
 
   const isButtonDisabled = () => {
-    return !(hasValue(tokenInput) && hasValue(tenderInput) && isTokenApproved) || isPendingTransaction(addLiquidityTx);
+    // if either field has an invalid value return false
+    if (!hasValue(tokenInput) || !hasValue(tenderInput)) return false;
+    // if a transaction is pending return false
+    if (isPendingTransaction(addLiquidityTx)) return false;
+    // if underlying token (e.g. LPT) has no permit support and is not approved, return false
+    if (!hasPermit && !isTokenApproved) return false;
   };
 
-  const { addLiquidity, tx: addLiquidityTx } = useAddLiquidity(
-    addresses[protocolName].tenderToken,
-    protocolName,
-    account,
-    addresses[protocolName].tenderSwap,
-    symbol,
-    isTenderApproved
-  );
+  const { addLiquidity, tx: addLiquidityTx } = useAddLiquidity(protocolName, isTokenApproved, isTenderApproved);
 
   const lpTokenAmount = useCalculateLpTokenAmount(
     addresses[protocolName].tenderSwap,
@@ -213,7 +214,7 @@ const JoinPool: FC<Props> = ({ protocolName, symbol, tokenBalance, tenderTokenBa
                       symbol={symbol}
                       spender={addresses[protocolName].tenderSwap}
                       token={contracts[protocolName].token}
-                      show={!isTokenApproved}
+                      show={!hasPermit && !isTokenApproved}
                       chainId={stakers[protocolName].chainId}
                     />
                   )

--- a/packages/app/src/pages/stakers/[slug].tsx
+++ b/packages/app/src/pages/stakers/[slug].tsx
@@ -217,6 +217,7 @@ const DropdownBackground = styled.div`
 
 const TokenWrapper: FC<{ config?: TenderizeConfig }> = (props) => {
   const dappConfig: Config = {
+    pollingInterval: 2500,
     readOnlyUrls: props.config?.chainUrlMapping,
   };
 

--- a/packages/app/src/utils/tenderDepositHooks.ts
+++ b/packages/app/src/utils/tenderDepositHooks.ts
@@ -1,0 +1,48 @@
+import { useContractFunction, useEthers } from "@usedapp/core";
+import { contracts, addresses } from "@tender/contracts";
+import { BigNumber } from "ethers";
+import { signERC2612Permit } from "eth-permit";
+import stakers from "data/stakers";
+import { getDeadline } from "./tenderSwapHooks";
+
+export const useDeposit = (protocolName: string) => {
+  const symbol = stakers[protocolName].symbol;
+  const hasPermit = stakers[protocolName].hasPermit;
+
+  const { state: depositTx, send: depositWithApprove } = useContractFunction(
+    contracts[protocolName].tenderizer,
+    "deposit",
+    {
+      transactionName: `Deposit ${symbol}`,
+    }
+  );
+
+  const { state: depositWithPermitTx, send: depositWithPermit } = useContractFunction(
+    contracts[protocolName].tenderizer,
+    "depositWithPermit",
+    {
+      transactionName: `Deposit ${symbol}`,
+    }
+  );
+
+  const { library, account } = useEthers();
+
+  const deposit = async (amount: BigNumber) => {
+    if (hasPermit) {
+      const permit = await signERC2612Permit(
+        library?.getSigner(),
+        addresses[protocolName].token,
+        account || "",
+        addresses[protocolName].tenderizer,
+        amount?.toString(),
+        getDeadline()
+      );
+
+      await depositWithPermit(amount, permit.deadline, permit.v, permit.r, permit.s);
+    } else {
+      await depositWithApprove(amount);
+    }
+  };
+
+  return { deposit, tx: hasPermit ? depositWithPermitTx : depositTx };
+};


### PR DESCRIPTION
- Added permit support for deposit if `hasPermit` is true (which means token , e.g. LPT, support permit)
- Added permit support for swapping and adding liquidity in case `hasPermit` is true
- Cleaned up `useAddLiquidity` hook arguments
- Decreased polling interval in config