### PR TITLE
replace grommet change validation with custom form validation

### DIFF
--- a/packages/app/src/components/deposit/index.tsx
+++ b/packages/app/src/components/deposit/index.tsx
@@ -11,7 +11,7 @@ import { AmountInputFooter } from "components/AmountInputFooter";
 import { LoadingButtonContent } from "components/LoadingButtonContent";
 import { weiToEthWithDecimals } from "utils/amountFormat";
 import { isPendingTransaction } from "utils/transactions";
-import { validateIsLargerThanMax, validateIsPositive } from "utils/inputValidation";
+import { useBalanceValidation } from "utils/inputValidation";
 import stakers from "data/stakers";
 import Faucet from "components/faucet";
 import { useIsCorrectChain } from "utils/useEnsureRinkebyConnect";
@@ -73,6 +73,8 @@ const Deposit: FC<Props> = ({ protocolName, symbol, logo, tokenBalance, tenderTo
     depositInput
   );
 
+  const { validationMessage } = useBalanceValidation(depositInput, tokenBalance);
+
   const claimedRewards = BigNumber.from(data?.userDeployments?.[0]?.claimedRewards ?? "0");
   const tenderizerStake = BigNumber.from(data?.userDeployments?.[0]?.tenderizerStake ?? "0");
   const myRewards = claimedRewards.add(tenderTokenBalance).sub(tenderizerStake);
@@ -104,15 +106,10 @@ const Deposit: FC<Props> = ({ protocolName, symbol, logo, tokenBalance, tenderTo
             <SwitchNetwork chainId={requiredChain} protocol={stakers[protocolName].title} />
           </Box>
         ) : (
-          <Form validate="change">
+          <Form>
             <Box align="center" justify="center">
               <Box width="490px" gap="small" direction="column">
-                <FormField
-                  fill
-                  label="Stake Amount"
-                  name="depositAmount"
-                  validate={[validateIsPositive(depositInput), validateIsLargerThanMax(depositInput, tokenBalance)]}
-                >
+                <FormField fill label="Stake Amount" name="depositAmount">
                   <TextInput
                     value={depositInput}
                     onChange={handleInputChange}
@@ -126,6 +123,7 @@ const Deposit: FC<Props> = ({ protocolName, symbol, logo, tokenBalance, tenderTo
                     style={{ textAlign: "right", padding: "20px 50px" }}
                     placeholder={`0`}
                   />
+                  <Text color="red">{validationMessage}</Text>
                   <AmountInputFooter
                     label={`Balance: ${weiToEthWithDecimals(tokenBalance?.toString() || "0", 6)} ${symbol}`}
                     onClick={maxDeposit}

--- a/packages/app/src/components/farm/farm.tsx
+++ b/packages/app/src/components/farm/farm.tsx
@@ -19,7 +19,7 @@ import { useIsTokenApproved } from "../approve/useIsTokenApproved";
 import { AmountInputFooter } from "../AmountInputFooter";
 import { FormAdd, FormClose } from "grommet-icons";
 import { LoadingButtonContent } from "../LoadingButtonContent";
-import { validateIsLargerThanMax, validateIsPositive } from "utils/inputValidation";
+import { useBalanceValidation } from "utils/inputValidation";
 import { useEthers } from "@usedapp/core";
 import { isPendingTransaction } from "utils/transactions";
 import { useFarm } from "utils/tenderFarmHooks";
@@ -65,6 +65,8 @@ const Farm: FC<Props> = ({ protocolName, symbol, tokenBalance }) => {
     setFarmInput("");
   };
 
+  const { validationMessage } = useBalanceValidation(farmInput, tokenBalance);
+
   return (
     <>
       <Button primary onClick={handleShow} label="Farm" reverse icon={<FormAdd color="white" />} />
@@ -88,11 +90,8 @@ const Farm: FC<Props> = ({ protocolName, symbol, tokenBalance }) => {
               </Heading>
             </CardHeader>
             <CardBody pad={{ top: "medium", horizontal: "large" }} align="center">
-              <Form validate="change" style={{ width: "100%" }}>
-                <FormField
-                  protocolName="farmInput"
-                  validate={[validateIsPositive(farmInput), validateIsLargerThanMax(farmInput, tokenBalance)]}
-                >
+              <Form style={{ width: "100%" }}>
+                <FormField protocolName="farmInput">
                   <TextInput
                     value={farmInput}
                     onChange={handleFarmInputChange}
@@ -105,6 +104,7 @@ const Farm: FC<Props> = ({ protocolName, symbol, tokenBalance }) => {
                     }
                     style={{ textAlign: "right", padding: "20px 50px" }}
                   />
+                  <Text color="red">{validationMessage}</Text>
                   <AmountInputFooter
                     label={`Balance: ${weiToEthWithDecimals(tokenBalance?.toString() || "0", 6)} ${symbol}`}
                     onClick={maxDeposit}

--- a/packages/app/src/components/farm/unfarm.tsx
+++ b/packages/app/src/components/farm/unfarm.tsx
@@ -18,7 +18,7 @@ import {
 import { AmountInputFooter } from "../AmountInputFooter";
 import { FormClose, FormSubtract } from "grommet-icons";
 import { LoadingButtonContent } from "../LoadingButtonContent";
-import { validateIsLargerThanMax, validateIsPositive } from "utils/inputValidation";
+import { useBalanceValidation } from "utils/inputValidation";
 import { useContractFunction } from "@usedapp/core";
 import { isPendingTransaction } from "utils/transactions";
 import { weiToEthWithDecimals } from "utils/amountFormat";
@@ -54,6 +54,8 @@ const Unfarm: FC<Props> = ({ protocolName, symbol, stake }) => {
     await unfarm(utils.parseEther(unfarmInput || "0"));
     setUnfarmInput("");
   };
+
+  const { validationMessage } = useBalanceValidation(unfarmInput, stake);
 
   return (
     <>
@@ -91,11 +93,8 @@ const Unfarm: FC<Props> = ({ protocolName, symbol, stake }) => {
             </CardHeader>
             <CardBody>
               <Box pad={{ top: "medium", horizontal: "large" }} align="center">
-                <Form validate="change" style={{ width: "100%" }}>
-                  <FormField
-                    label="Unfarm Amount"
-                    validate={[validateIsPositive(unfarmInput), validateIsLargerThanMax(unfarmInput, stake)]}
-                  >
+                <Form style={{ width: "100%" }}>
+                  <FormField label="Unfarm Amount">
                     <TextInput
                       value={unfarmInput}
                       onChange={handleUnfarmInputChange}
@@ -108,6 +107,7 @@ const Unfarm: FC<Props> = ({ protocolName, symbol, stake }) => {
                       }
                       style={{ textAlign: "right", padding: "20px 50px" }}
                     />
+                    <Text color="red">{validationMessage}</Text>
                     <AmountInputFooter
                       label={`Current Stake: ${weiToEthWithDecimals(stake?.toString() || "0", 6)} ${symbol}`}
                       onClick={maxUnfarm}

--- a/packages/app/src/components/swap/exit.tsx
+++ b/packages/app/src/components/swap/exit.tsx
@@ -23,7 +23,7 @@ import {
 import { useIsTokenApproved } from "../approve/useIsTokenApproved";
 import { AmountInputFooter } from "../AmountInputFooter";
 import { LoadingButtonContent } from "../LoadingButtonContent";
-import { validateIsLargerThanMax, validateIsPositive } from "../../utils/inputValidation";
+import { useBalanceValidation } from "../../utils/inputValidation";
 import stakers from "../../data/stakers";
 import { useEthers } from "@usedapp/core";
 import { weiToEthWithDecimals } from "../../utils/amountFormat";
@@ -159,7 +159,7 @@ const ExitPool: FC<Props> = ({ protocolName, symbol, lpTokenBalance }) => {
                   }
                 >
                   <Box pad={{ top: "medium", horizontal: "large" }} align="center">
-                    <Form validate="change" style={{ width: "100%" }}>
+                    <Form style={{ width: "100%" }}>
                       <Box gap="medium">
                         <LPTokensToRemoveInputField
                           lpTokenBalance={lpTokenBalance}
@@ -310,12 +310,10 @@ const LPTokensToRemoveInputField: FC<{
     [setLpSharesInput]
   );
 
+  const { validationMessage } = useBalanceValidation(lpSharesInput, lpTokenBalance);
+
   return (
-    <FormField
-      label="LP Tokens to remove"
-      name="lpTokenToRemove"
-      validate={[validateIsPositive(lpSharesInput), validateIsLargerThanMax(lpSharesInput, lpTokenBalance)]}
-    >
+    <FormField label="LP Tokens to remove" name="lpTokenToRemove">
       <Box direction="row" align="center" gap="small">
         <TextInput
           value={lpSharesInput}
@@ -325,6 +323,7 @@ const LPTokensToRemoveInputField: FC<{
           style={{ textAlign: "right", padding: "20px 50px" }}
         />
       </Box>
+      <Text color="red">{validationMessage}</Text>
       <AmountInputFooter
         label={`Staked: ${weiToEthWithDecimals(lpTokenBalance?.toString() || "0", 6)} ${symbolFull}`}
         onClick={maxDeposit}

--- a/packages/app/src/components/swap/join.tsx
+++ b/packages/app/src/components/swap/join.tsx
@@ -21,7 +21,7 @@ import { useIsTokenApproved } from "components/approve/useIsTokenApproved";
 import { AmountInputFooter } from "components/AmountInputFooter";
 import { LoadingButtonContent } from "components/LoadingButtonContent";
 import { useCalculateLpTokenAmount, useAddLiquidity } from "utils/tenderSwapHooks";
-import { validateIsPositive, validateIsLargerThanMax, hasValue } from "utils/inputValidation";
+import { hasValue, useBalanceValidation } from "utils/inputValidation";
 import { isPendingTransaction } from "utils/transactions";
 import { weiToEthWithDecimals } from "utils/amountFormat";
 import stakers from "data/stakers";
@@ -111,6 +111,9 @@ const JoinPool: FC<Props> = ({ protocolName, symbol, tokenBalance, tenderTokenBa
     addLiquidity(tenderIn, tokenIn, lpTokenAmount.sub(1));
   };
 
+  const { validationMessage: tokenValidationMessage } = useBalanceValidation(tokenInput, tokenBalance);
+  const { validationMessage: tenderValidationMessage } = useBalanceValidation(tenderInput, tenderTokenBalance);
+
   return (
     <Box pad={{ horizontal: "large", top: "small" }}>
       <Button primary onClick={handleShow} label="Add Liquidity" />
@@ -135,13 +138,9 @@ const JoinPool: FC<Props> = ({ protocolName, symbol, tokenBalance, tenderTokenBa
             </CardHeader>
             <CardBody>
               <Box pad={{ top: "medium", horizontal: "large" }} align="center">
-                <Form validate="change" style={{ width: "100%" }}>
+                <Form style={{ width: "100%" }}>
                   <Box gap="medium">
-                    <FormField
-                      label={`${symbol} Amount`}
-                      protocolName="tokenInput"
-                      validate={[validateIsPositive(tokenInput), validateIsLargerThanMax(tokenInput, tokenBalance)]}
-                    >
+                    <FormField label={`${symbol} Amount`} protocolName="tokenInput">
                       <TextInput
                         value={tokenInput}
                         onChange={handleTokenInputChange}
@@ -155,19 +154,13 @@ const JoinPool: FC<Props> = ({ protocolName, symbol, tokenBalance, tenderTokenBa
                         style={{ textAlign: "right", padding: "20px 50px" }}
                         placeholder={"0"}
                       />
+                      <Text color="red">{tokenValidationMessage}</Text>
                       <AmountInputFooter
                         label={`Balance: ${weiToEthWithDecimals(tokenBalance?.toString() || "0", 6)} ${symbol}`}
                         onClick={maxTokenDeposit}
                       />
                     </FormField>
-                    <FormField
-                      label={`t${symbol} Amount`}
-                      protocolName="tenderInput"
-                      validate={[
-                        validateIsPositive(tenderInput),
-                        validateIsLargerThanMax(tenderInput, tenderTokenBalance),
-                      ]}
-                    >
+                    <FormField label={`t${symbol} Amount`} protocolName="tenderInput">
                       <TextInput
                         value={tenderInput}
                         onChange={handleTenderInputChange}
@@ -181,6 +174,7 @@ const JoinPool: FC<Props> = ({ protocolName, symbol, tokenBalance, tenderTokenBa
                         style={{ textAlign: "right", padding: "20px 50px" }}
                         placeholder={"0"}
                       />
+                      <Text color="red">{tenderValidationMessage}</Text>
                       <AmountInputFooter
                         label={`Balance: ${weiToEthWithDecimals(tenderTokenBalance?.toString() || "0", 6)} t${symbol}`}
                         onClick={maxTenderTokenDeposit}

--- a/packages/app/src/components/swap/swap.tsx
+++ b/packages/app/src/components/swap/swap.tsx
@@ -9,7 +9,7 @@ import { useIsTokenApproved } from "../approve/useIsTokenApproved";
 import { Transaction } from "grommet-icons";
 import { ethWithDecimals, weiToEthWithDecimals } from "../../utils/amountFormat";
 import { AmountInputFooter } from "../AmountInputFooter";
-import { isLargerThanMax, isPositive, validateIsLargerThanMax, validateIsPositive } from "../../utils/inputValidation";
+import { isLargerThanMax, isPositive, useBalanceValidation } from "../../utils/inputValidation";
 import { useCalculateSwap } from "../../utils/tenderSwapHooks";
 import { useEthers } from "@usedapp/core";
 
@@ -80,20 +80,14 @@ const Swap: FC<Props> = ({ tokenSymbol, tokenBalance, tenderTokenBalance, protoc
     setReceiveTokenAmount(utils.formatEther(calcOutGivenIn || "0"));
   }, [calcOutGivenIn]);
 
+  const { validationMessage } = useBalanceValidation(sendTokenAmount, sendTokenBalance, sendTokenSymbol);
+
   return (
     <Box>
-      <Form validate="change">
+      <Form>
         <Box align="center" justify="center">
           <Box direction="row" gap="small">
-            <FormField
-              disabled={disabled}
-              name="sendAmount"
-              label={`Send`}
-              validate={[
-                validateIsPositive(sendTokenAmount),
-                validateIsLargerThanMax(sendTokenAmount, sendTokenBalance),
-              ]}
-            >
+            <FormField disabled={disabled} name="sendAmount" label={`Send`}>
               <Box width="medium">
                 <TextInput
                   disabled={disabled}
@@ -112,6 +106,7 @@ const Swap: FC<Props> = ({ tokenSymbol, tokenBalance, tenderTokenBalance, protoc
                   onChange={handleSendTokenInput}
                   required={true}
                 />
+                <Text color="red">{validationMessage}</Text>
                 <AmountInputFooter
                   label={`Balance: ${weiToEthWithDecimals(sendTokenBalance, 6)} ${sendTokenSymbol}`}
                   onClick={() => {

--- a/packages/app/src/utils/inputValidation.ts
+++ b/packages/app/src/utils/inputValidation.ts
@@ -1,4 +1,5 @@
 import { BigNumberish, utils } from "ethers";
+import { useEffect, useState } from "react";
 
 type ValidateFunction = () => { message: string; status: "error" | "info" } | undefined;
 
@@ -18,3 +19,24 @@ export const validateIsLargerThanMax =
     isLargerThanMax(val, max) ? { message: "Amount exceeds available balance", status: "error" } : undefined;
 
 export const hasValue = (val: BigNumberish) => val != null && val !== "0";
+
+export const useBalanceValidation = (input: string, balance: BigNumberish, extraDep?: string) => {
+  const [validationMessage, setValidationMessage] = useState<string>();
+
+  useEffect(() => {
+    if (input !== "") {
+      const isPos = isPositive(input);
+      const isLTMax = isLargerThanMax(input, balance);
+
+      if (!isPos) {
+        setValidationMessage("Please provide a valid amount");
+      } else if (isLTMax) {
+        setValidationMessage("Amount exceeds available balance");
+      } else {
+        setValidationMessage(undefined);
+      }
+    }
+  }, [input, balance, extraDep]);
+
+  return { validationMessage };
+};


### PR DESCRIPTION
fixes #213 

The grommet #help slack channel acknowledged the bug, I opened an issue https://github.com/grommet/grommet/issues/5961. The suggested workaround about dispatching change events manually did not help. 

Spent some time digging through the implementation what else could we do but figured at this point it's easier to just add a simple implementation for our very narrow usecase is easier.