### PR TITLE
better price wording in swap

### DIFF
--- a/packages/app/src/components/swap/ConfirmSwapModal.tsx
+++ b/packages/app/src/components/swap/ConfirmSwapModal.tsx
@@ -170,7 +170,12 @@ const ConfirmSwapModal: FC<Props> = ({
                       </FormField>
                     </Box>
                     <Box pad={{ vertical: "medium" }} justify="center" align="center">
-                      <Text>Price: {`${weiToEthWithDecimals(tokenSpotPrice, 5)} ${tokenSendedSymbol}`} </Text>
+                      <Text>
+                        {`Exchange rate: ${weiToEthWithDecimals(
+                          tokenSpotPrice,
+                          5
+                        )} ${tokenSendedSymbol} / ${tokenReceivedSymbol}`}
+                      </Text>
                     </Box>
                   </Form>
                 )}


### PR DESCRIPTION
price now reads as: `exchange rate: 1.0006 MATIC / tMATIC` in swap dialog