### PR TITLE
use ghost for blog content on landing

### DIFF
--- a/packages/landing/src/components/medium/BlogContainer.tsx
+++ b/packages/landing/src/components/medium/BlogContainer.tsx
@@ -4,14 +4,14 @@ import styled from "styled-components";
 import { Foot } from "@tender/shared/src/index";
 import { ScreenSize, screenToFontSize } from "../highlights/helper";
 import { HighlightContainer } from "../highlights/HighlightContainer";
-import { useMedium } from "./helper";
+import { useBlog } from "./helper";
 
 export const BlogContainer: FC<{ screenSize: ScreenSize; setVisibleIndex: (v: number) => void; index: number }> = ({
   screenSize,
   setVisibleIndex,
   index,
 }) => {
-  const { blog } = useMedium();
+  const { blog } = useBlog();
 
   const renderPosts = () => {
     if (blog.posts.length === 0) {

--- a/packages/landing/src/components/medium/MobileBlogContainer.tsx
+++ b/packages/landing/src/components/medium/MobileBlogContainer.tsx
@@ -1,10 +1,10 @@
 import { Box, Heading, Paragraph, Text } from "grommet";
 import { FC } from "react";
 import styled from "styled-components";
-import { ToText, useMedium } from "./helper";
+import { ToText, useBlog } from "./helper";
 
 export const MobileBlogContainer: FC = () => {
-  const { blog } = useMedium();
+  const { blog } = useBlog();
 
   const renderPosts = () => {
     if (blog.posts.length === 0) {

--- a/packages/landing/src/components/medium/helper.ts
+++ b/packages/landing/src/components/medium/helper.ts
@@ -10,7 +10,7 @@ export const ToText = (node: any) => {
   return node;
 };
 
-export const useMedium = () => {
+export const useBlog = () => {
   const [blog, setBlog] = useState<{ posts: any[]; isLoading: boolean; error: string | null }>({
     posts: [],
     isLoading: true,

--- a/packages/landing/src/pages/api/medium.ts
+++ b/packages/landing/src/pages/api/medium.ts
@@ -1,7 +1,7 @@
 import { NextApiResponse, NextApiRequest } from "next";
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
-  const data = await fetch("https://api.rss2json.com/v1/api.json?rss_url=https://medium.com/feed/@tenderize");
+  const data = await fetch("https://api.rss2json.com/v1/api.json?rss_url=https://blog.tenderize.me/rss/");
   const jsonObj = await data.json();
   res.status(200).json(jsonObj);
 };


### PR DESCRIPTION
Updated to our new rss feed.

Looked into using `rss-parser` instead of relying on a 3rd party service, but it seems like Ghost is putting the cover image to a non-standard place, which is not supported by that lib. Luckily the 3rd party rss2json.com can handle it.