### PR TITLE
Fix bugs from Gnosis feedback

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,9 +5,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ develop ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, develop ]
 
 jobs:
   build:

--- a/packages/app/src/components/approve/useIsTokenApproved.ts
+++ b/packages/app/src/components/approve/useIsTokenApproved.ts
@@ -1,5 +1,5 @@
 import { useCall } from "@usedapp/core";
-import { Contract, utils } from "ethers";
+import { Contract, utils, constants, BigNumber } from "ethers";
 import { abis } from "@tender/contracts/src/index";
 import { ERC20 } from "@tender/contracts/gen/types";
 
@@ -15,14 +15,13 @@ export const useIsTokenApproved = (
     useCall(
       tokenAddress &&
         ownerAddress &&
-        spenderAddress &&
-        amount && {
+        spenderAddress && {
           contract,
           method: "allowance",
           args: [ownerAddress, spenderAddress],
         }
     ) ?? {};
-
   const amountWei = utils.parseEther(amount || "0");
-  return allowance?.[0].gte(amountWei) ?? false;
+  const allowanceParsed: BigNumber = allowance?.[0] || constants.Zero;
+  return amountWei ? amountWei.lte(allowanceParsed) : !allowanceParsed.isZero();
 };

--- a/packages/app/src/components/swap/AddLiquidity.tsx
+++ b/packages/app/src/components/swap/AddLiquidity.tsx
@@ -90,12 +90,12 @@ const AddLiquidity: FC<Props> = ({ protocolName, symbol, tokenBalance, tenderTok
   );
 
   const isButtonDisabled = () => {
-    // if either field has an invalid value return false
-    if (!hasValue(tokenInput) || !hasValue(tenderInput)) return false;
-    // if a transaction is pending return false
-    if (isPendingTransaction(addLiquidityTx)) return false;
-    // if underlying token (e.g. LPT) has no permit support and is not approved, return false
-    if (!hasPermit && !isTokenApproved) return false;
+    // if either field has an invalid value return true
+    if (!hasValue(tokenInput) || !hasValue(tenderInput)) return true;
+    // if a transaction is pending return true
+    if (isPendingTransaction(addLiquidityTx)) return true;
+    // if underlying token (e.g. LPT) has no permit support and is not approved, return true
+    if (!hasPermit && !isTokenApproved) return true;
   };
 
   const { addLiquidity, tx: addLiquidityTx } = useAddLiquidity(protocolName, isTokenApproved, isTenderApproved);


### PR DESCRIPTION
- Fixes #291 : Hide "Approve Token" button when user has an allowance but the input field is still empty. From feedback this confuses users into thinking the token hasn't been approved yet. 

- Fixes #290 : The "Add Liquidity" button wasn't disabled when the form fields were empty allowing users to think they weren't required and giving an error in the console. 

- This PR doesn't fix the long wait time for a transaction to confirm through gnosis safe. After investigation we think it's because we wait until the transaction confirm through the gnosis safe provider which seem to take longer than other providers.