### PR TITLE
fix gnosis safe ERC20Permit usage

### DIFF
--- a/packages/app/src/components/account/index.tsx
+++ b/packages/app/src/components/account/index.tsx
@@ -16,6 +16,7 @@ import { constants } from "ethers";
 
 export const AccountButton: FC<{ config: TenderizeConfig }> = ({ config }) => {
   const { account, deactivate, activate, activateBrowserWallet, chainId } = useEthers();
+
   const ens = useLookupAddress();
   const [showAccountInfo, setShowAccountInfo] = useState(false);
   const [showWalletPicker, setShowWalletPicker] = useState(false);

--- a/packages/app/src/components/deposit/index.tsx
+++ b/packages/app/src/components/deposit/index.tsx
@@ -100,7 +100,7 @@ const Deposit: FC<Props> = ({ protocolName, symbol, logo, tokenBalance, tenderTo
   const myRewards = claimedRewards.add(tenderTokenBalance).sub(tenderizerStake);
   const nonNegativeRewards = myRewards.isNegative() ? constants.Zero : myRewards;
 
-  const isSafeContext = isGnosisSafe()
+  const isSafeContext = isGnosisSafe();
 
   return (
     <Box>

--- a/packages/app/src/components/deposit/index.tsx
+++ b/packages/app/src/components/deposit/index.tsx
@@ -1,5 +1,6 @@
 import { FC, useEffect, useState } from "react";
 import { addresses, contracts } from "@tender/contracts/src/index";
+import { isGnosisSafe } from "utils/context";
 import { ArbitrumRinkeby, Rinkeby, useEthers } from "@usedapp/core";
 import { BigNumber, BigNumberish, utils, constants } from "ethers";
 import { Button, Box, Form, FormField, Image, Text, TextInput } from "grommet";
@@ -98,6 +99,9 @@ const Deposit: FC<Props> = ({ protocolName, symbol, logo, tokenBalance, tenderTo
   const tenderizerStake = BigNumber.from(data?.userDeployments?.[0]?.tenderizerStake ?? "0");
   const myRewards = claimedRewards.add(tenderTokenBalance).sub(tenderizerStake);
   const nonNegativeRewards = myRewards.isNegative() ? constants.Zero : myRewards;
+
+  const isSafeContext = isGnosisSafe()
+
   return (
     <Box>
       <Box gap="medium" pad={{ bottom: "medium" }}>
@@ -150,7 +154,7 @@ const Deposit: FC<Props> = ({ protocolName, symbol, logo, tokenBalance, tenderTo
                     symbol={symbol}
                     spender={addresses[protocolName].tenderizer}
                     token={contracts[protocolName].token}
-                    show={!hasPermit && !isTokenApproved}
+                    show={(!hasPermit || isSafeContext) && !isTokenApproved}
                     chainId={stakers[protocolName].chainId}
                   />
                   <Button

--- a/packages/app/src/components/farm/farm.tsx
+++ b/packages/app/src/components/farm/farm.tsx
@@ -72,7 +72,7 @@ const Farm: FC<Props> = ({ protocolName, symbol, tokenBalance }) => {
     setFarmInput("");
   };
 
-  const isSafeContext = isGnosisSafe()
+  const isSafeContext = isGnosisSafe();
 
   const { validationMessage } = useBalanceValidation(farmInput, tokenBalance);
 
@@ -123,13 +123,13 @@ const Farm: FC<Props> = ({ protocolName, symbol, tokenBalance }) => {
             </CardBody>
             <CardFooter align="center" justify="center" pad={{ top: "medium" }}>
               <Box justify="center" gap="small">
-              <ApproveToken
-                    symbol={symbol}
-                    spender={addresses[protocolName].tenderizer}
-                    token={contracts[protocolName].token}
-                    show={!isTokenApproved && isSafeContext}
-                    chainId={stakers[protocolName].chainId}
-                  />
+                <ApproveToken
+                  symbol={symbol}
+                  spender={addresses[protocolName].tenderizer}
+                  token={contracts[protocolName].token}
+                  show={!isTokenApproved && isSafeContext}
+                  chainId={stakers[protocolName].chainId}
+                />
                 <Button
                   primary
                   style={{ width: 467 }}

--- a/packages/app/src/components/farm/farm.tsx
+++ b/packages/app/src/components/farm/farm.tsx
@@ -1,5 +1,7 @@
 import { FC, useCallback, useState } from "react/index";
-import { addresses } from "@tender/contracts/src/index";
+import { addresses, contracts } from "@tender/contracts/src/index";
+import { stakers } from "@tender/shared/src/index";
+import { isGnosisSafe } from "utils/context";
 import { BigNumberish, utils } from "ethers";
 import {
   Button,
@@ -15,6 +17,7 @@ import {
   Text,
   TextInput,
 } from "grommet";
+import ApproveToken from "components/approve/ApproveToken";
 import { useIsTokenApproved } from "../approve/useIsTokenApproved";
 import { AmountInputFooter } from "../AmountInputFooter";
 import { FormAdd, FormClose } from "grommet-icons";
@@ -59,7 +62,7 @@ const Farm: FC<Props> = ({ protocolName, symbol, tokenBalance }) => {
   );
 
   // Contract Functions
-  const { farmTx, farm } = useFarm(account, protocolName, symbol, isTokenApproved);
+  const { farmTx, farm } = useFarm(account, protocolName, symbol);
 
   useResetInputAfterTx(farmTx, setFarmInput);
 
@@ -68,6 +71,8 @@ const Farm: FC<Props> = ({ protocolName, symbol, tokenBalance }) => {
     await farm(utils.parseEther(farmInput || "0"));
     setFarmInput("");
   };
+
+  const isSafeContext = isGnosisSafe()
 
   const { validationMessage } = useBalanceValidation(farmInput, tokenBalance);
 
@@ -118,6 +123,13 @@ const Farm: FC<Props> = ({ protocolName, symbol, tokenBalance }) => {
             </CardBody>
             <CardFooter align="center" justify="center" pad={{ top: "medium" }}>
               <Box justify="center" gap="small">
+              <ApproveToken
+                    symbol={symbol}
+                    spender={addresses[protocolName].tenderizer}
+                    token={contracts[protocolName].token}
+                    show={!isTokenApproved && isSafeContext}
+                    chainId={stakers[protocolName].chainId}
+                  />
                 <Button
                   primary
                   style={{ width: 467 }}

--- a/packages/app/src/components/swap/AddLiquidity.tsx
+++ b/packages/app/src/components/swap/AddLiquidity.tsx
@@ -29,6 +29,7 @@ import { useEthers } from "@usedapp/core";
 import { FormClose } from "grommet-icons";
 import { useResetInputAfterTx } from "utils/useResetInputAfterTx";
 import { ProtocolName } from "@tender/shared/src/data/stakers";
+import { isGnosisSafe } from "utils/context";
 
 type Props = {
   protocolName: ProtocolName;
@@ -89,13 +90,15 @@ const AddLiquidity: FC<Props> = ({ protocolName, symbol, tokenBalance, tenderTok
     tenderInput
   );
 
+  const isSafeContext = isGnosisSafe()
+
   const isButtonDisabled = () => {
     // if either field has an invalid value return true
     if (!hasValue(tokenInput) || !hasValue(tenderInput)) return true;
     // if a transaction is pending return true
     if (isPendingTransaction(addLiquidityTx)) return true;
     // if underlying token (e.g. LPT) has no permit support and is not approved, return true
-    if (!hasPermit && !isTokenApproved) return true;
+    if ((!hasPermit || isSafeContext) && !isTokenApproved) return true;
   };
 
   const { addLiquidity, tx: addLiquidityTx } = useAddLiquidity(protocolName, isTokenApproved, isTenderApproved);
@@ -218,9 +221,20 @@ const AddLiquidity: FC<Props> = ({ protocolName, symbol, tokenBalance, tenderTok
                       symbol={symbol}
                       spender={addresses[protocolName].tenderSwap}
                       token={contracts[protocolName].token}
-                      show={!hasPermit && !isTokenApproved}
+                      show={(!hasPermit || isSafeContext) && !isTokenApproved}
                       chainId={stakers[protocolName].chainId}
                     />
+                  )
+                  }
+                  {
+                  !isTenderApproved && (
+                    <ApproveToken
+                    symbol={bwTenderLogo}
+                    spender={addresses[protocolName].tenderSwap}
+                    token={contracts[protocolName].tenderToken}
+                    show={isSafeContext && !isTenderApproved}
+                    chainId={stakers[protocolName].chainId}
+                  />
                   )
                 }
                 <Button

--- a/packages/app/src/components/swap/AddLiquidity.tsx
+++ b/packages/app/src/components/swap/AddLiquidity.tsx
@@ -90,7 +90,7 @@ const AddLiquidity: FC<Props> = ({ protocolName, symbol, tokenBalance, tenderTok
     tenderInput
   );
 
-  const isSafeContext = isGnosisSafe()
+  const isSafeContext = isGnosisSafe();
 
   const isButtonDisabled = () => {
     // if either field has an invalid value return true
@@ -225,18 +225,16 @@ const AddLiquidity: FC<Props> = ({ protocolName, symbol, tokenBalance, tenderTok
                       chainId={stakers[protocolName].chainId}
                     />
                   )
-                  }
-                  {
-                  !isTenderApproved && (
-                    <ApproveToken
+                }
+                {!isTenderApproved && (
+                  <ApproveToken
                     symbol={bwTenderLogo}
                     spender={addresses[protocolName].tenderSwap}
                     token={contracts[protocolName].tenderToken}
                     show={isSafeContext && !isTenderApproved}
                     chainId={stakers[protocolName].chainId}
                   />
-                  )
-                }
+                )}
                 <Button
                   primary
                   onClick={handleAddLiquidity}

--- a/packages/app/src/components/swap/swap.tsx
+++ b/packages/app/src/components/swap/swap.tsx
@@ -54,14 +54,14 @@ const Swap: FC<Props> = ({ tokenSymbol, tokenBalance, tenderTokenBalance, protoc
 
   const sendInputRef = useRef<HTMLInputElement | null>(null);
 
-  const isSafeContext = isGnosisSafe()
+  const isSafeContext = isGnosisSafe();
 
   const showApprove = (): boolean => {
     if (disabled) return false;
     if (isSafeContext && !isTokenApproved) return true;
     if (isSendingToken && !hasPermit && !isTokenApproved) return true;
     return false;
-  }
+  };
 
   const calcOutGivenIn = useCalculateSwap(
     addresses[protocolName].tenderSwap,

--- a/packages/app/src/utils/context.ts
+++ b/packages/app/src/utils/context.ts
@@ -1,0 +1,21 @@
+import { useEthers } from "@usedapp/core";
+import { stakers } from "@tender/shared/src/index";
+import { ProtocolName } from "@tender/shared/src/data/stakers";
+
+type isGnosisSafe = () => boolean
+type hasPermit = (protocol: ProtocolName) => boolean
+
+export function isGnosisSafe(): boolean {
+    const { library } = useEthers();
+    const lib: any = library
+    // Usedapp uses JsonRpcProvider type from ethersjs which is unaware of the "provider" property.
+    // In reality the returned value can be of other types as well under the hood.
+    // Therefore we overwrite the type so we can check whether the provider has the 'safe' property
+    // indicating that we are in a gnosis safe context
+    return lib?.provider.hasOwnProperty('safe')
+}
+
+export function hasPermit(protocol: ProtocolName): boolean {
+    return stakers[protocol].hasPermit;
+}
+

--- a/packages/app/src/utils/context.ts
+++ b/packages/app/src/utils/context.ts
@@ -2,20 +2,19 @@ import { useEthers } from "@usedapp/core";
 import { stakers } from "@tender/shared/src/index";
 import { ProtocolName } from "@tender/shared/src/data/stakers";
 
-type isGnosisSafe = () => boolean
-type hasPermit = (protocol: ProtocolName) => boolean
+type isGnosisSafe = () => boolean;
+type hasPermit = (protocol: ProtocolName) => boolean;
 
 export function isGnosisSafe(): boolean {
-    const { library } = useEthers();
-    const lib: any = library
-    // Usedapp uses JsonRpcProvider type from ethersjs which is unaware of the "provider" property.
-    // In reality the returned value can be of other types as well under the hood.
-    // Therefore we overwrite the type so we can check whether the provider has the 'safe' property
-    // indicating that we are in a gnosis safe context
-    return lib?.provider.hasOwnProperty('safe')
+  const { library } = useEthers();
+  const lib: any = library;
+  // Usedapp uses JsonRpcProvider type from ethersjs which is unaware of the "provider" property.
+  // In reality the returned value can be of other types as well under the hood.
+  // Therefore we overwrite the type so we can check whether the provider has the 'safe' property
+  // indicating that we are in a gnosis safe context
+  return lib?.provider.hasOwnProperty("safe");
 }
 
 export function hasPermit(protocol: ProtocolName): boolean {
-    return stakers[protocol].hasPermit;
+  return stakers[protocol].hasPermit;
 }
-

--- a/packages/app/src/utils/tenderDepositHooks.ts
+++ b/packages/app/src/utils/tenderDepositHooks.ts
@@ -3,7 +3,7 @@ import { contracts, addresses } from "@tender/contracts/src/index";
 import { BigNumber } from "ethers";
 import { stakers } from "@tender/shared/src/index";
 import { getDeadline } from "./tenderSwapHooks";
-import { isGnosisSafe, hasPermit } from "./context" 
+import { isGnosisSafe, hasPermit } from "./context";
 import { signERC2612PermitPatched } from "./signERC2612PermitPatch";
 import { ProtocolName } from "@tender/shared/src/data/stakers";
 

--- a/packages/app/src/utils/tenderDepositHooks.ts
+++ b/packages/app/src/utils/tenderDepositHooks.ts
@@ -3,12 +3,12 @@ import { contracts, addresses } from "@tender/contracts/src/index";
 import { BigNumber } from "ethers";
 import { stakers } from "@tender/shared/src/index";
 import { getDeadline } from "./tenderSwapHooks";
+import { isGnosisSafe, hasPermit } from "./context" 
 import { signERC2612PermitPatched } from "./signERC2612PermitPatch";
 import { ProtocolName } from "@tender/shared/src/data/stakers";
 
 export const useDeposit = (protocolName: ProtocolName) => {
   const symbol = stakers[protocolName].symbol;
-  const hasPermit = stakers[protocolName].hasPermit;
 
   const { state: depositTx, send: depositWithApprove } = useContractFunction(
     contracts[protocolName].tenderizer,
@@ -29,7 +29,10 @@ export const useDeposit = (protocolName: ProtocolName) => {
   const { library, account } = useEthers();
 
   const deposit = async (amount: BigNumber) => {
-    if (hasPermit) {
+    if (!hasPermit(protocolName) || isGnosisSafe()) {
+      // TODO: We expect token to be already approved here but don't actually check such invariant
+      await depositWithApprove(amount);
+    } else {
       const permit = await signERC2612PermitPatched(
         library?.getSigner(),
         addresses[protocolName].token,
@@ -40,10 +43,8 @@ export const useDeposit = (protocolName: ProtocolName) => {
       );
 
       await depositWithPermit(amount, permit.deadline, permit.v, permit.r, permit.s);
-    } else {
-      await depositWithApprove(amount);
     }
   };
 
-  return { deposit, tx: hasPermit ? depositWithPermitTx : depositTx };
+  return { deposit, tx: hasPermit(protocolName) ? depositWithPermitTx : depositTx };
 };

--- a/packages/app/src/utils/tenderFarmHooks.ts
+++ b/packages/app/src/utils/tenderFarmHooks.ts
@@ -4,15 +4,10 @@ import { BigNumber } from "ethers";
 import { getDeadline } from "./tenderSwapHooks";
 import { signERC2612PermitPatched } from "./signERC2612PermitPatch";
 import { ProtocolName } from "@tender/shared/src/data/stakers";
-import { isGnosisSafe } from "./context" 
+import { isGnosisSafe } from "./context";
 
-export const useFarm = (
-  owner: string | undefined | null,
-  protocolName: ProtocolName,
-  symbol: string,
-) => {
-
-  const isSafe = isGnosisSafe()
+export const useFarm = (owner: string | undefined | null, protocolName: ProtocolName, symbol: string) => {
+  const isSafe = isGnosisSafe();
   // Contract Functions
   const { state: farmTx, send } = useContractFunction(
     contracts[protocolName].tenderFarm,

--- a/packages/app/src/utils/tenderSwapHooks.ts
+++ b/packages/app/src/utils/tenderSwapHooks.ts
@@ -6,6 +6,7 @@ import { TenderSwap } from "@tender/contracts/gen/types";
 import { weiToEthInFloat } from "./amountFormat";
 import { signERC2612PermitPatched } from "./signERC2612PermitPatch";
 import { ProtocolName } from "@tender/shared/src/data/stakers";
+import { isGnosisSafe, hasPermit } from "./context";
 
 const TenderSwapABI = new utils.Interface(abis.tenderSwap);
 
@@ -354,7 +355,7 @@ export const useAddLiquidity = (protocolName: ProtocolName, isTokenApproved: boo
   const multicallData: string[] = [];
 
   const addLiquidity = async (tenderIn: BigNumber, tokenIn: BigNumber, lpTokenAmount: BigNumber) => {
-    if (!isTenderApproved) {
+    if (!isTenderApproved && !isGnosisSafe()) {
       const tenderToken = addresses[protocolName].tenderToken;
       const permit = await signERC2612PermitPatched(
         library?.getSigner(),
@@ -377,7 +378,7 @@ export const useAddLiquidity = (protocolName: ProtocolName, isTokenApproved: boo
       );
     }
 
-    if (!tokenIn.isZero() && stakers[protocolName].hasPermit && !isTokenApproved) {
+    if (!tokenIn.isZero() && hasPermit(protocolName) && !isTokenApproved && !isGnosisSafe()) {
       const token = addresses[protocolName].token;
       const permit = await signERC2612PermitPatched(
         library?.getSigner(),


### PR DESCRIPTION
Since Gnosis Safes are a smart contract they cannot sign ERC20 Permit messages for token approvals. Currently when a token supports ERC20Permit, the only option we provide to users is to use signature-based approvals. However in case of gnosis safe or other smart contract wallets we also want to allow regular token approvals. 

