### PR TITLE
remove 'derivative' from copy

### DIFF
--- a/packages/landing/src/components/highlights/Deployments.tsx
+++ b/packages/landing/src/components/highlights/Deployments.tsx
@@ -84,14 +84,13 @@ export const Deployments: FC<{ screenSize: ScreenSize; setVisibleIndex: (v: numb
             }}
             size={screenToFontSize(screenSize)}
           >
-            Tender Tokens
+            TenderTokens
           </Heading>
           <Paragraph margin={{ top: "medium" }} size={"large"} style={{ fontWeight: 500 }}>
-            Liquid staking derivatives pegged 1:1 to your staked assets
+            Liquid staking tokens pegged 1:1 to your staked assets
           </Paragraph>
           <Paragraph margin={{ top: "small" }} size={"medium"}>
-            Your TenderToken balance will increase as Tenderize earns staking rewards so you earn yield simply by
-            holding them.
+            TenderTokens automatically compound staking rewards which reflects directly in your wallet
           </Paragraph>
         </Box>
       </Grid>

--- a/packages/landing/src/components/highlights/DeploymentsMobile.tsx
+++ b/packages/landing/src/components/highlights/DeploymentsMobile.tsx
@@ -29,11 +29,10 @@ export const DeploymentsMobile: FC = () => {
         size="medium"
         style={{ fontWeight: 500 }}
       >
-        Liquid staking derivatives pegged 1:1 to your staked assets
+        Liquid staking tokens pegged 1:1 to your staked assets
       </Paragraph>
       <Paragraph textAlign="center" margin={{ vertical: "small", horizontal: "medium" }} size="medium">
-        Your TenderToken balance will increase as Tenderize earns staking rewards so you earn yield simply by holding
-        them.
+        TenderTokens automatically compound staking rewards which reflects directly in your wallet
       </Paragraph>
       <Box direction="column" pad={{ top: "large" }} gap="large">
         <TokenCardMobile key={graph.path} {...graph} tvl={tvl.graph.tvl} />


### PR DESCRIPTION
Avoid using the word "derivative" in the website copy