### PR TITLE
Time-weights for reward periods when calculating APY

### DIFF
--- a/packages/shared/src/calculateAPY.ts
+++ b/packages/shared/src/calculateAPY.ts
@@ -36,7 +36,7 @@ export const calculateAPY = (data: Queries.TenderizerDaysType | undefined): Reco
     const normalizeApys = apysBasedOnSingleEvents.slice(1).map(o => o.apy * o.timeDiff)
     const final = normalizeApys.reduce((p, n) => p + n) / totalTimePassed
 
-    const apy = final ? (final * 100).toFixed(2) : 0;
+    const apy = final ? (final * 100).toFixed(2) : "0";
     return {
       ...staker,
       apy,
@@ -45,6 +45,7 @@ export const calculateAPY = (data: Queries.TenderizerDaysType | undefined): Reco
 
   const stakersWithAPYMap = {} as Record<ProtocolName, Staker>;
   for (const staker of stakersWithAPY) {
+    if (staker == 0) continue;
     stakersWithAPYMap[staker.name] = staker;
   }
   return stakersWithAPYMap;

--- a/packages/shared/src/calculateAPY.ts
+++ b/packages/shared/src/calculateAPY.ts
@@ -45,7 +45,7 @@ export const calculateAPY = (data: Queries.TenderizerDaysType | undefined): Reco
 
   const stakersWithAPYMap = {} as Record<ProtocolName, Staker>;
   for (const staker of stakersWithAPY) {
-    if (staker == 0) continue;
+    if (staker === 0) continue;
     stakersWithAPYMap[staker.name] = staker;
   }
   return stakersWithAPYMap;

--- a/packages/shared/src/calculateAPY.ts
+++ b/packages/shared/src/calculateAPY.ts
@@ -2,42 +2,41 @@ import { Queries, stakers, Staker } from "@tender/shared/src/index";
 import { ProtocolName } from "./data/stakers";
 
 const YEAR_IN_SECONDS = 60 * 60 * 24 * 365;
+type apycalc = { apy: number, timeDiff: number }
 
 export const calculateAPY = (data: Queries.TenderizerDaysType | undefined): Record<Staker["name"], Staker> => {
   const stakersWithAPY = Object.values(stakers).map((staker) => {
-    let apyInPoints = 0;
-    if (data != null) {
-      const tenderizerData = data.tenderizers.find((item) => item.id.includes(staker.subgraphId)) ?? {
-        id: staker.subgraphId,
-        rewardsClaimedEvents: [],
-      };
-      const rewardsClaimedEvents = tenderizerData.rewardsClaimedEvents.filter((item) => item.rewards !== "0");
+    if (data == null) return 0;
 
-      if (rewardsClaimedEvents.length === 0) {
-        apyInPoints = 0;
-      } else {
-        const apysBasedOnSingleEvents = rewardsClaimedEvents
+    const tenderizerData = data.tenderizers.find((item) => item.id.includes(staker.subgraphId)) ?? {
+      id: staker.subgraphId,
+      rewardsClaimedEvents: [],
+    };
+    const rewardsClaimedEvents = tenderizerData.rewardsClaimedEvents.filter((item) => item.rewards !== "0");
+    let totalTimePassed = 0
+    const apysBasedOnSingleEvents: Array<apycalc> = rewardsClaimedEvents
+      .map((value, index) => {
+        console.log(value)
+        // we need the first value's timestamp but not the rewards
+        if (index === 0) {
+          return { apy: 0, timeDiff: 0 };
+        }
 
-          .map((value, index) => {
-            // we need the first value's timestamp but not the rewards
-            if (index === 0) {
-              return null;
-            }
+        const currentEvent = value;
+        const previousEvent = rewardsClaimedEvents[index - 1];
 
-            const currentEvent = value;
-            const previousEvent = rewardsClaimedEvents[index - 1];
-            const rate = Number.parseFloat(currentEvent.rewards) / Number.parseFloat(currentEvent.oldPrincipal);
-            const timeDiff = currentEvent.timestamp - previousEvent.timestamp;
-            const compoundsPerYear = Math.floor(YEAR_IN_SECONDS / timeDiff);
-            const apy = Math.pow(1 + rate, compoundsPerYear) - 1;
-            return apy;
-          })
-          .filter((item): item is number => item != null);
-        apyInPoints =
-          apysBasedOnSingleEvents.reduce((prev, current) => prev + current, 0) / apysBasedOnSingleEvents.length;
-      }
-    }
-    const apy = (apyInPoints * 100).toFixed(2);
+        const rate = Number.parseFloat(currentEvent.rewards) / Number.parseFloat(currentEvent.oldPrincipal);
+        const timeDiff = currentEvent.timestamp - previousEvent.timestamp;
+        totalTimePassed += timeDiff
+        const compoundsPerYear = Math.floor(YEAR_IN_SECONDS / timeDiff);
+        const apy = Math.pow(1 + rate, compoundsPerYear) - 1;
+        return { apy: apy || 0, timeDiff: timeDiff || 0 };
+      })
+
+    const normalizeApys = apysBasedOnSingleEvents.slice(1).map(o => o.apy * o.timeDiff)
+    const final = normalizeApys.reduce((p, n) => p + n) / totalTimePassed
+
+    const apy = final ? (final * 100).toFixed(2) : 0;
     return {
       ...staker,
       apy,

--- a/packages/shared/src/calculateAPY.ts
+++ b/packages/shared/src/calculateAPY.ts
@@ -2,7 +2,7 @@ import { Queries, stakers, Staker } from "@tender/shared/src/index";
 import { ProtocolName } from "./data/stakers";
 
 const YEAR_IN_SECONDS = 60 * 60 * 24 * 365;
-type apycalc = { apy: number, timeDiff: number }
+type apycalc = { apy: number; timeDiff: number };
 
 export const calculateAPY = (data: Queries.TenderizerDaysType | undefined): Record<Staker["name"], Staker> => {
   const stakersWithAPY = Object.values(stakers).map((staker) => {
@@ -13,28 +13,27 @@ export const calculateAPY = (data: Queries.TenderizerDaysType | undefined): Reco
       rewardsClaimedEvents: [],
     };
     const rewardsClaimedEvents = tenderizerData.rewardsClaimedEvents.filter((item) => item.rewards !== "0");
-    let totalTimePassed = 0
-    const apysBasedOnSingleEvents: Array<apycalc> = rewardsClaimedEvents
-      .map((value, index) => {
-        console.log(value)
-        // we need the first value's timestamp but not the rewards
-        if (index === 0) {
-          return { apy: 0, timeDiff: 0 };
-        }
+    let totalTimePassed = 0;
+    const apysBasedOnSingleEvents: Array<apycalc> = rewardsClaimedEvents.map((value, index) => {
+      console.log(value);
+      // we need the first value's timestamp but not the rewards
+      if (index === 0) {
+        return { apy: 0, timeDiff: 0 };
+      }
 
-        const currentEvent = value;
-        const previousEvent = rewardsClaimedEvents[index - 1];
+      const currentEvent = value;
+      const previousEvent = rewardsClaimedEvents[index - 1];
 
-        const rate = Number.parseFloat(currentEvent.rewards) / Number.parseFloat(currentEvent.oldPrincipal);
-        const timeDiff = currentEvent.timestamp - previousEvent.timestamp;
-        totalTimePassed += timeDiff
-        const compoundsPerYear = Math.floor(YEAR_IN_SECONDS / timeDiff);
-        const apy = Math.pow(1 + rate, compoundsPerYear) - 1;
-        return { apy: apy || 0, timeDiff: timeDiff || 0 };
-      })
+      const rate = Number.parseFloat(currentEvent.rewards) / Number.parseFloat(currentEvent.oldPrincipal);
+      const timeDiff = currentEvent.timestamp - previousEvent.timestamp;
+      totalTimePassed += timeDiff;
+      const compoundsPerYear = Math.floor(YEAR_IN_SECONDS / timeDiff);
+      const apy = Math.pow(1 + rate, compoundsPerYear) - 1;
+      return { apy: apy || 0, timeDiff: timeDiff || 0 };
+    });
 
-    const normalizeApys = apysBasedOnSingleEvents.slice(1).map(o => o.apy * o.timeDiff)
-    const final = normalizeApys.reduce((p, n) => p + n) / totalTimePassed
+    const normalizeApys = apysBasedOnSingleEvents.slice(1).map((o) => o.apy * o.timeDiff);
+    const final = normalizeApys.reduce((p, n) => p + n) / totalTimePassed;
 
     const apy = final ? (final * 100).toFixed(2) : "0";
     return {

--- a/packages/shared/src/queries/index.ts
+++ b/packages/shared/src/queries/index.ts
@@ -109,6 +109,7 @@ export const GetTenderizerDays = gql`
         timestamp
         rewards
         oldPrincipal
+        currentPrincipal
       }
     }
   }


### PR DESCRIPTION
Currently we calculate the APY based on each reward period, then take an average based on the number of events. 

This PR changes the calculation to a time-weighted average of each reward period rather than a flat average. 

This intends to improve handling of protocols with irregular reward periods