### PR TITLE
Local Subgraph Development Environment

### DIFF
--- a/packages/subgraph/README.md
+++ b/packages/subgraph/README.md
@@ -38,21 +38,17 @@ Replace `paulrberg/create-eth-app` in the package.json script with your subgraph
 
 You may also want to [read more about the hosted service](https://thegraph.com/docs/quick-start#hosted-service).
 
-## Learn More
+## Deploy Subgraph Locally
 
-To learn The Graph, check out the [The Graph documentation](https://thegraph.com/docs).
+1. Install [Docker](https://docs.docker.com) and [Docker Compose](https://docs.docker.com/compose/install/)
+2. Inside `docker-compose.yml`, set the `ethereum` value under the `environment` section to an archive node that has tracing enabled. If you don't have access to an archive node we recommend using [Alchemy](https://alchemyapi.io/).
+3. In the root of this project run `docker-compose up`. This command will look for the `docker-compose.yml` file and automatically provision a server with rust, postgres, and ipfs, and spin up a graph node with a GraphiQL interface at `http://127.0.0.1:8000/`.
 
----
+4. Run `yarn create:local` to create the subgraph
+5. Run `yarn deploy:local` to deploy it
 
-1. Generate types
-2. Build distributable files
-3. Deploy to the remote API
-
-## Learn More
-
-You can learn more in the [The Graph documentation](https://thegraph.com/docs).<br/>
-
-Also consider joining [The Graph Discord server](https://discord.gg/vtvv7FP), where you can seek out help.
+After downloading the latest blocks from Ethereum, you should begin to see smart contract events flying in. Open a GraphiQL browser at
+localhost:8000 to query the Graph Node.s
 
 ## Common Errors
 
@@ -71,7 +67,7 @@ Make sure that you followed the instructions listed above for [yarn auth](#yarn-
 
 ### Failed to Deploy
 
-> ✖ Failed to deploy to Graph node https://api.thegraph.com/deploy/: Invalid account name or access token
+> ✖ Failed to deploy to Graph node <https://api.thegraph.com/deploy/>: Invalid account name or access token
 
 Make sure that you:
 

--- a/packages/subgraph/docker-compose.yaml
+++ b/packages/subgraph/docker-compose.yaml
@@ -11,12 +11,12 @@ services:
       - ipfs
       - postgres
     environment:
-      postgres_host: postgres:5432
+      postgres_host: postgres
       postgres_user: graph-node
       postgres_pass: let-me-in
       postgres_db: graph-node
       ipfs: 'ipfs:5001'
-      ethereum: 'https://eth-mainnet.alchemyapi.io/jsonrpc/[API_KEY]'
+      ethereum: 'mainnet:http://host.docker.internal:8545'
   ipfs:
     image: ipfs/go-ipfs
     container_name: ipfs

--- a/packages/subgraph/docker-compose.yaml
+++ b/packages/subgraph/docker-compose.yaml
@@ -1,0 +1,37 @@
+version: '3'
+services:
+  graph-node:
+    image: graphprotocol/graph-node:latest
+    container_name: graph-node
+    ports:
+      - '8000:8000'
+      - '8001:8001'
+      - '8020:8020'
+    depends_on:
+      - ipfs
+      - postgres
+    environment:
+      postgres_host: postgres:5432
+      postgres_user: graph-node
+      postgres_pass: let-me-in
+      postgres_db: graph-node
+      ipfs: 'ipfs:5001'
+      ethereum: 'https://eth-mainnet.alchemyapi.io/jsonrpc/[API_KEY]'
+  ipfs:
+    image: ipfs/go-ipfs
+    container_name: ipfs
+    ports:
+      - '5001:5001'
+    volumes:
+      - ./data/ipfs:/data/ipfs
+  postgres:
+    image: postgres
+    container_name: postgres
+    ports:
+      - '5432:5432'
+    environment:
+      POSTGRES_USER: graph-node
+      POSTGRES_PASSWORD: let-me-in
+      POSTGRES_DB: graph-node
+    volumes:
+      - ./data/postgres:/var/lib/postgresql/data

--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -8,6 +8,7 @@
   },
   "license": "MIT",
   "scripts": {
+    "create:local": "graph create tenderize/tenderize --node http://127.0.0.1:8020",
     "prepare": "node ./templatify.js",
     "prepare:rinkeby": "NETWORK_NAME=rinkeby node ./templatify.js",
     "prepare:arbitrum-rinkeby": "NETWORK_NAME=arbitrum-rinkeby node ./templatify.js",
@@ -16,7 +17,8 @@
     "build": "graph build",
     "codegen": "graph codegen --output-dir src/types/",
     "deploy": "graph deploy tenderize/tenderize --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
-    "deploy:staging": "graph deploy tenderize/tenderize-staging --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/"
+    "deploy:staging": "graph deploy tenderize/tenderize-staging --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
+    "deploy:local": "graph deploy tenderize/tenderize --debug --ipfs http://127.0.0.1:5001 --node http://127.0.0.1:8020"
   },
   "devDependencies": {
     "fs-extra": "^10.0.0",

--- a/packages/subgraph/templatify.js
+++ b/packages/subgraph/templatify.js
@@ -12,10 +12,10 @@ Handlebars.registerHelper("ifEquals", function (arg1, arg2, options) {
 function getNetworkNameForSubgraph() {
   switch (process.env.SUBGRAPH) {
     case undefined:
-    case "livepeer/livepeer":
+    case "tenderize/tenderize":
       return "mainnet";
-    case "livepeer/livepeer-rinkeby":
-      return "rinkeby";
+    case "tenderize/tenderize-arbitrum":
+      return "arbitrum";
     default:
       return null;
   }


### PR DESCRIPTION
This PR adds a docker compose to easily spin up a local graph node. 

You can then deploy a subgraph locally instead of on the hosted service connected to an ethereum network on localhost for development purposes.