### PR TITLE
manually set slippage for add liquidity

### DIFF
--- a/packages/app/src/components/SlippageInput.tsx
+++ b/packages/app/src/components/SlippageInput.tsx
@@ -19,6 +19,7 @@ export const SlippageInput: FC<{ slippage: number; setSlippage: (v: number) => v
       <Box>
         <TextInput
           id="slippage"
+          type="number"
           value={slippage}
           width={30}
           maxLength={2}

--- a/packages/app/src/components/SlippageInput.tsx
+++ b/packages/app/src/components/SlippageInput.tsx
@@ -1,0 +1,32 @@
+import { Box, Button, Text, TextInput } from "grommet";
+import { FC } from "react";
+
+export const SlippageInput: FC<{ slippage: number; setSlippage: (v: number) => void; auto: number }> = ({
+  slippage,
+  setSlippage,
+  auto,
+}) => {
+  return (
+    <Box direction="row" justify="end" align="center" gap="small">
+      <Text>Set slippage</Text>
+      <Button
+        size="small"
+        label="auto"
+        onClick={() => {
+          setSlippage(auto);
+        }}
+      />
+      <Box>
+        <TextInput
+          id="slippage"
+          value={slippage}
+          width={30}
+          maxLength={2}
+          style={{ textAlign: "right", padding: "5px 5px", width: 60 }}
+          onChange={(e) => setSlippage(Number.parseInt(e.target.value === "" ? "0" : e.target.value))}
+        />
+      </Box>
+      %
+    </Box>
+  );
+};

--- a/packages/app/src/components/deposit/TxWarning.tsx
+++ b/packages/app/src/components/deposit/TxWarning.tsx
@@ -1,0 +1,44 @@
+import { Box, Text, Tip } from "grommet";
+import { FC } from "react";
+
+export const TxWarning: FC<{ errorInfo: string | undefined; errorMessage: string | undefined }> = ({
+  errorMessage,
+  errorInfo,
+}) => {
+  return (
+    <>
+      {errorMessage != null && (
+        <Box justify="center" align="center" direction="row" gap="small" pad={{ horizontal: "xsmall" }}>
+          <Text color="red">{errorMessage}</Text>
+          <Tip
+            plain
+            dropProps={{
+              round: {
+                size: "20px",
+              },
+              background: "rgba(0,0,0,0.7)",
+              elevation: "none",
+            }}
+            content={
+              <Box width="medium" elevation="none" pad="medium">
+                <Text>{errorInfo}</Text>
+              </Box>
+            }
+          >
+            <span
+              style={{
+                border: "1px solid red",
+                borderRadius: "50%",
+                paddingLeft: "5px",
+                paddingRight: "5px",
+                color: "red",
+              }}
+            >
+              &#8505;
+            </span>
+          </Tip>
+        </Box>
+      )}
+    </>
+  );
+};

--- a/packages/app/src/components/swap/AddLiquidity.tsx
+++ b/packages/app/src/components/swap/AddLiquidity.tsx
@@ -15,7 +15,6 @@ import {
   TextInput,
   Text,
   Heading,
-  Tip,
 } from "grommet";
 import ApproveToken from "components/approve/ApproveToken";
 import { useIsTokenApproved } from "components/approve/useIsTokenApproved";
@@ -28,11 +27,12 @@ import { weiToEthWithDecimals, withDecimals } from "utils/amountFormat";
 import { stakers } from "@tender/shared/src/index";
 import { useEthers } from "@usedapp/core";
 import { FormClose } from "grommet-icons";
-import { useResetInputAfterTx } from "utils/useResetInputAfterTx";
+import { useCloseAfterTx } from "utils/useResetInputAfterTx";
 import { ProtocolName } from "@tender/shared/src/data/stakers";
 import { useIsGnosisSafe } from "utils/context";
 import { SlippageInput } from "components/SlippageInput";
 import { useLPTokenOut } from "utils/useLPTokenOut";
+import { TxWarning } from "components/deposit/TxWarning";
 import { useWarningOnTxFailure } from "utils/useWarningOnTxFailure";
 
 type Props = {
@@ -121,10 +121,7 @@ const AddLiquidity: FC<Props> = ({ protocolName, symbol, tokenBalance, tenderTok
   const { validationMessage: tokenValidationMessage } = useBalanceValidation(tokenInput, tokenBalance);
   const { validationMessage: tenderValidationMessage } = useBalanceValidation(tenderInput, tenderTokenBalance);
 
-  useResetInputAfterTx(addLiquidityTx, (input: string) => {
-    setTokenInput(input);
-    setTenderInput(input);
-  });
+  useCloseAfterTx(addLiquidityTx, handleClose);
 
   const { priceImpact } = useLiquidityPriceImpact(addresses[protocolName].tenderSwap, true, tokenInput, tenderInput);
 
@@ -252,42 +249,12 @@ const AddLiquidity: FC<Props> = ({ protocolName, symbol, tokenBalance, tenderTok
                     )
                   }
                 />
-                {errorMessage != null && (
-                  <Box justify="center" align="center" direction="row" gap="small" pad={{ horizontal: "xsmall" }}>
-                    <Text color="red">
-                      {errorInfo?.includes("Couldn't mint min requested")
-                        ? "Slippage threshold is too low."
-                        : errorMessage}
-                    </Text>
-                    <Tip
-                      plain
-                      dropProps={{
-                        round: {
-                          size: "20px",
-                        },
-                        background: "rgba(0,0,0,0.7)",
-                        elevation: "none",
-                      }}
-                      content={
-                        <Box width="medium" elevation="none" pad="medium">
-                          <Text>{errorInfo}</Text>
-                        </Box>
-                      }
-                    >
-                      <span
-                        style={{
-                          border: "1px solid red",
-                          borderRadius: "50%",
-                          paddingLeft: "5px",
-                          paddingRight: "5px",
-                          color: "red",
-                        }}
-                      >
-                        &#8505;
-                      </span>
-                    </Tip>
-                  </Box>
-                )}
+                <TxWarning
+                  errorMessage={
+                    errorInfo?.includes("Couldn't mint min requested") ? "Slippage threshold is too low." : errorMessage
+                  }
+                  errorInfo={errorInfo}
+                />
               </Box>
             </CardFooter>
           </Card>

--- a/packages/app/src/components/swap/AddLiquidity.tsx
+++ b/packages/app/src/components/swap/AddLiquidity.tsx
@@ -1,6 +1,6 @@
-import { FC, useState, ChangeEventHandler, MouseEventHandler } from "react";
+import { FC, useState, ChangeEventHandler, MouseEventHandler, useEffect } from "react";
 import { addresses, contracts } from "@tender/contracts/src/index";
-import { BigNumberish, utils } from "ethers";
+import { BigNumberish, constants, utils } from "ethers";
 import {
   Image,
   Button,
@@ -23,13 +23,14 @@ import { LoadingButtonContent } from "components/LoadingButtonContent";
 import { useCalculateLpTokenAmount, useAddLiquidity, useLiquidityPriceImpact } from "utils/tenderSwapHooks";
 import { hasValue, useBalanceValidation } from "utils/inputValidation";
 import { isPendingTransaction } from "utils/transactions";
-import { weiToEthWithDecimals, withDecimals } from "utils/amountFormat";
+import { weiToEthInFloat, weiToEthWithDecimals, withDecimals } from "utils/amountFormat";
 import { stakers } from "@tender/shared/src/index";
 import { useEthers } from "@usedapp/core";
 import { FormClose } from "grommet-icons";
 import { useResetInputAfterTx } from "utils/useResetInputAfterTx";
 import { ProtocolName } from "@tender/shared/src/data/stakers";
 import { useIsGnosisSafe } from "utils/context";
+import { SlippageInput } from "components/SlippageInput";
 
 type Props = {
   protocolName: ProtocolName;
@@ -44,7 +45,6 @@ const AddLiquidity: FC<Props> = ({ protocolName, symbol, tokenBalance, tenderTok
   const bwTenderLogo = `/${staker.bwTenderLogo}`;
   const [show, setShow] = useState(false);
   const { account } = useEthers();
-
   // whether supported asset (e.g. LPT) has ERC20 permit support
   const hasPermit = stakers[protocolName].hasPermit;
 
@@ -52,7 +52,6 @@ const AddLiquidity: FC<Props> = ({ protocolName, symbol, tokenBalance, tenderTok
   const handleShow = () => setShow(true);
 
   const [tokenInput, setTokenInput] = useState("");
-
   const [tenderInput, setTenderInput] = useState("");
 
   const lpTokenSymbol = `t${symbol}-SWAP`;
@@ -103,17 +102,39 @@ const AddLiquidity: FC<Props> = ({ protocolName, symbol, tokenBalance, tenderTok
 
   const { addLiquidity, tx: addLiquidityTx } = useAddLiquidity(protocolName, isTokenApproved, isTenderApproved);
 
-  const lpTokenAmount = useCalculateLpTokenAmount(
+  const defaultLPTokenOut = useCalculateLpTokenAmount(
     addresses[protocolName].tenderSwap,
     [utils.parseEther(tenderInput || "0"), utils.parseEther(tokenInput || "0")],
     true
   );
 
+  const [lpTokenMinOut, setLPTokenMinOut] = useState(defaultLPTokenOut);
+
+  const sumIn = utils.parseEther(tokenInput || "0").add(utils.parseEther(tenderInput || "0"));
+  const defaultSlippage = defaultLPTokenOut.eq(constants.Zero)
+    ? 0
+    : Math.round(Math.abs((1 - weiToEthInFloat(sumIn) / weiToEthInFloat(defaultLPTokenOut)) * 100) * 100) / 100;
+  const [slippage, setSlippage] = useState(defaultSlippage);
+
+  useEffect(() => {
+    if (!defaultLPTokenOut.eq(constants.Zero)) {
+      setSlippage(defaultSlippage);
+    }
+  }, [defaultLPTokenOut]);
+
+  useEffect(() => {
+    const tokenIn = utils.parseEther(tokenInput || "0");
+    const tenderIn = utils.parseEther(tenderInput || "0");
+    const sumIn = tokenIn.add(tenderIn);
+    const outMin = sumIn.sub(sumIn.mul(slippage * 100).div(10000));
+    setLPTokenMinOut(outMin);
+  }, [slippage, tokenInput, tenderInput]);
+
   const handleAddLiquidity: MouseEventHandler<HTMLButtonElement & HTMLAnchorElement> = async (e) => {
     e.preventDefault();
     const tokenIn = utils.parseEther(tokenInput || "0");
     const tenderIn = utils.parseEther(tenderInput || "0");
-    addLiquidity(tenderIn, tokenIn, lpTokenAmount.sub(1), isSafeContext);
+    addLiquidity(tenderIn, tokenIn, lpTokenMinOut.sub(1), isSafeContext);
   };
 
   const { validationMessage: tokenValidationMessage } = useBalanceValidation(tokenInput, tokenBalance);
@@ -196,7 +217,7 @@ const AddLiquidity: FC<Props> = ({ protocolName, symbol, tokenBalance, tenderTok
                       <TextInput
                         readOnly
                         disabled
-                        value={weiToEthWithDecimals(lpTokenAmount, 6)}
+                        value={weiToEthWithDecimals(lpTokenMinOut, 6)}
                         placeholder={"0"}
                         type="number"
                         style={{ textAlign: "right", padding: "20px 50px" }}
@@ -207,6 +228,7 @@ const AddLiquidity: FC<Props> = ({ protocolName, symbol, tokenBalance, tenderTok
                         }
                       />
                     </FormField>
+                    <SlippageInput slippage={slippage} setSlippage={setSlippage} auto={defaultSlippage} />
                     <Text textAlign="end">{`Price impact: ${withDecimals((priceImpact * 100).toString(), 2)} %`}</Text>
                   </Box>
                 </Form>

--- a/packages/app/src/components/swap/AddLiquidity.tsx
+++ b/packages/app/src/components/swap/AddLiquidity.tsx
@@ -117,10 +117,8 @@ const AddLiquidity: FC<Props> = ({ protocolName, symbol, tokenBalance, tenderTok
   const [slippage, setSlippage] = useState(defaultSlippage);
 
   useEffect(() => {
-    if (!defaultLPTokenOut.eq(constants.Zero)) {
-      setSlippage(defaultSlippage);
-    }
-  }, [defaultLPTokenOut]);
+    setSlippage(defaultSlippage);
+  }, [defaultSlippage]);
 
   useEffect(() => {
     const tokenIn = utils.parseEther(tokenInput || "0");

--- a/packages/app/src/components/swap/AddLiquidity.tsx
+++ b/packages/app/src/components/swap/AddLiquidity.tsx
@@ -15,6 +15,7 @@ import {
   TextInput,
   Text,
   Heading,
+  Tip,
 } from "grommet";
 import ApproveToken from "components/approve/ApproveToken";
 import { useIsTokenApproved } from "components/approve/useIsTokenApproved";
@@ -32,6 +33,7 @@ import { ProtocolName } from "@tender/shared/src/data/stakers";
 import { useIsGnosisSafe } from "utils/context";
 import { SlippageInput } from "components/SlippageInput";
 import { useLPTokenOut } from "utils/useLPTokenOut";
+import { useWarningOnTxFailure } from "utils/useWarningOnTxFailure";
 
 type Props = {
   protocolName: ProtocolName;
@@ -94,7 +96,7 @@ const AddLiquidity: FC<Props> = ({ protocolName, symbol, tokenBalance, tenderTok
 
   const isButtonDisabled = () => {
     // if either field has an invalid value return true
-    if (!hasValue(tokenInput) || !hasValue(tenderInput)) return true;
+    if (!hasValue(tokenInput) && !hasValue(tenderInput)) return true;
     // if a transaction is pending return true
     if (isPendingTransaction(addLiquidityTx)) return true;
     // if underlying token (e.g. LPT) has no permit support and is not approved, return true
@@ -125,6 +127,8 @@ const AddLiquidity: FC<Props> = ({ protocolName, symbol, tokenBalance, tenderTok
   });
 
   const { priceImpact } = useLiquidityPriceImpact(addresses[protocolName].tenderSwap, true, tokenInput, tenderInput);
+
+  const { errorMessage, errorInfo } = useWarningOnTxFailure(addLiquidityTx);
 
   return (
     <Box pad={{ horizontal: "large", top: "small" }}>
@@ -248,6 +252,38 @@ const AddLiquidity: FC<Props> = ({ protocolName, symbol, tokenBalance, tenderTok
                     )
                   }
                 />
+                {errorMessage != null && (
+                  <Box justify="center" align="center" direction="row" gap="small" pad={{ horizontal: "xsmall" }}>
+                    <Text color="red">{errorMessage}</Text>
+                    <Tip
+                      plain
+                      dropProps={{
+                        round: {
+                          size: "20px",
+                        },
+                        background: "rgba(0,0,0,0.7)",
+                        elevation: "none",
+                      }}
+                      content={
+                        <Box width="medium" elevation="none" pad="medium">
+                          <Text>{errorInfo}</Text>
+                        </Box>
+                      }
+                    >
+                      <span
+                        style={{
+                          border: "1px solid red",
+                          borderRadius: "50%",
+                          paddingLeft: "5px",
+                          paddingRight: "5px",
+                          color: "red",
+                        }}
+                      >
+                        &#8505;
+                      </span>
+                    </Tip>
+                  </Box>
+                )}
               </Box>
             </CardFooter>
           </Card>

--- a/packages/app/src/components/swap/AddLiquidity.tsx
+++ b/packages/app/src/components/swap/AddLiquidity.tsx
@@ -254,7 +254,11 @@ const AddLiquidity: FC<Props> = ({ protocolName, symbol, tokenBalance, tenderTok
                 />
                 {errorMessage != null && (
                   <Box justify="center" align="center" direction="row" gap="small" pad={{ horizontal: "xsmall" }}>
-                    <Text color="red">{errorMessage}</Text>
+                    <Text color="red">
+                      {errorInfo?.includes("Couldn't mint min requested")
+                        ? "Slippage threshold is too low."
+                        : errorMessage}
+                    </Text>
                     <Tip
                       plain
                       dropProps={{

--- a/packages/app/src/components/swap/AddLiquidity.tsx
+++ b/packages/app/src/components/swap/AddLiquidity.tsx
@@ -192,7 +192,7 @@ const AddLiquidity: FC<Props> = ({ protocolName, symbol, tokenBalance, tenderTok
                         onClick={maxTenderTokenDeposit}
                       />
                     </FormField>
-                    <FormField label={`Amount of ${lpTokenSymbol} to receive`}>
+                    <FormField label={`Minimum amount of ${lpTokenSymbol} to receive`}>
                       <TextInput
                         readOnly
                         disabled

--- a/packages/app/src/components/swap/ConfirmSwapModal.tsx
+++ b/packages/app/src/components/swap/ConfirmSwapModal.tsx
@@ -28,6 +28,7 @@ import { weiToEthWithDecimals, withDecimals } from "utils/amountFormat";
 import { useBalanceValidation } from "utils/inputValidation";
 import { AmountInputFooter } from "components/AmountInputFooter";
 import { ProtocolName } from "@tender/shared/src/data/stakers";
+import { SlippageInput } from "components/SlippageInput";
 
 type Props = {
   show: boolean;
@@ -194,23 +195,7 @@ const ConfirmSwapModal: FC<Props> = ({
                     </Box>
                     <Box pad={{ vertical: "medium" }} gap="small" justify="center" align="right">
                       <Box direction="column" gap="small" alignSelf="end">
-                        <Box direction="row" justify="end" align="center" gap="small">
-                          <Text>Set slippage</Text>
-                          <Button size="small" label="auto" onClick={() => setSlippage(2)} />
-                          <Box>
-                            <TextInput
-                              id="slippage"
-                              value={slippage}
-                              width={30}
-                              maxLength={2}
-                              style={{ textAlign: "right", padding: "5px 5px", width: 60 }}
-                              onChange={(e) =>
-                                setSlippage(Number.parseInt(e.target.value === "" ? "0" : e.target.value))
-                              }
-                            />
-                          </Box>
-                          %
-                        </Box>
+                        <SlippageInput slippage={slippage} setSlippage={setSlippage} auto={2} />
                         <Text textAlign="end">
                           {`Minimum received after ${slippage}% slippage: ${weiToEthWithDecimals(
                             minAmount,

--- a/packages/app/src/components/swap/RemoveLiquidity.tsx
+++ b/packages/app/src/components/swap/RemoveLiquidity.tsx
@@ -37,7 +37,7 @@ import {
 import { FormClose } from "grommet-icons";
 import { isPendingTransaction } from "utils/transactions";
 import { useResetInputAfterTx } from "utils/useResetInputAfterTx";
-import { ProtocolName } from "@tender/shared/src/data/stakers";
+import { ProtocolName, Staker } from "@tender/shared/src/data/stakers";
 
 type Props = {
   protocolName: ProtocolName;
@@ -48,92 +48,10 @@ type Props = {
 const RemoveLiquidity: FC<Props> = ({ protocolName, symbol, lpTokenBalance }) => {
   const staker = stakers[protocolName];
   const [show, setShow] = useState(false);
-  const [tabIndex, setTabIndex] = useState(0);
-
   const handleClose = () => setShow(false);
   const handleShow = () => setShow(true);
 
-  const [isMulti, setIsMulti] = useState(true);
-  const [lpSharesInputMulti, setLpSharesInputMulti] = useState("");
-  const [lpSharesInputSingle, setLpSharesInputSingle] = useState("");
-
-  const [tokenOutput, setTokenOutput] = useState("");
-  const [tenderOutput, setTenderOutput] = useState("");
   const [selectedToken, setSelectedToken] = useState(symbol);
-  const { account } = useEthers();
-
-  const isLpSharesApproved = useIsTokenApproved(
-    addresses[protocolName].lpToken,
-    account,
-    addresses[protocolName].tenderSwap,
-    lpSharesInputMulti || lpSharesInputSingle
-  );
-
-  const { removeLiquiditySingleOut, tx: exitPoolSingleTx } = useExitPoolSingle(
-    addresses[protocolName].lpToken,
-    protocolName,
-    account,
-    addresses[protocolName].tenderSwap,
-    symbol,
-    isLpSharesApproved
-  );
-
-  const { removeLiquidity, exitPoolTx } = useExitPool(
-    addresses[protocolName].lpToken,
-    protocolName,
-    account,
-    addresses[protocolName].tenderSwap,
-    symbol,
-    isLpSharesApproved
-  );
-
-  useResetInputAfterTx(exitPoolTx, setLpSharesInputMulti);
-  useResetInputAfterTx(exitPoolSingleTx, setLpSharesInputSingle);
-
-  const singleTokenOutAddress =
-    selectedToken === symbol ? addresses[protocolName].token : addresses[protocolName].tenderToken;
-
-  const singleOut = useCalculateRemoveLiquidityOneToken(
-    addresses[protocolName].tenderSwap,
-    utils.parseEther(lpSharesInputSingle || "0"),
-    singleTokenOutAddress
-  );
-
-  const [tenderOut, tokenOut] = useCalculateRemoveLiquidity(
-    addresses[protocolName].tenderSwap,
-    utils.parseEther(lpSharesInputMulti || "0")
-  );
-
-  useEffect(() => {
-    setTokenOutput(weiToEthWithDecimals(tokenOut, 6));
-    setTenderOutput(weiToEthWithDecimals(tenderOut, 6));
-  }, [tenderOut, tokenOut]);
-
-  const handleRemoveLiquidity = async (e: any) => {
-    e.preventDefault();
-    if (isMulti) {
-      // NOTE: Pool cardinality is tenderToken/Token
-      await removeLiquidity(utils.parseEther(lpSharesInputMulti || "0"), tenderOut, tokenOut);
-    } else {
-      await removeLiquiditySingleOut(utils.parseEther(lpSharesInputSingle || "0"), singleTokenOutAddress, singleOut);
-    }
-  };
-
-  const { priceImpact } = useLiquidityPriceImpact(
-    addresses[protocolName].tenderSwap,
-    false,
-    selectedToken === symbol ? weiToEthWithDecimals(singleOut, 6) : "0",
-    selectedToken === symbol ? "0" : weiToEthWithDecimals(singleOut, 6)
-  );
-
-  const onActive = useCallback((nextIndex: number) => {
-    setTabIndex(nextIndex);
-    if (nextIndex === 0) {
-      setIsMulti(true);
-    } else {
-      setIsMulti(false);
-    }
-  }, []);
 
   const symbolFull = `t${symbol}-SWAP`;
 
@@ -160,7 +78,7 @@ const RemoveLiquidity: FC<Props> = ({ protocolName, symbol, lpTokenBalance }) =>
               </Heading>
             </CardHeader>
             <CardBody>
-              <Tabs id="exit-type" activeIndex={tabIndex} onActive={onActive}>
+              <Tabs id="exit-type">
                 <Tab
                   title={
                     <Box justify="center" align="center">
@@ -168,52 +86,14 @@ const RemoveLiquidity: FC<Props> = ({ protocolName, symbol, lpTokenBalance }) =>
                     </Box>
                   }
                 >
-                  <Box pad={{ top: "medium", horizontal: "large" }} align="center">
-                    <Form style={{ width: "100%" }}>
-                      <Box gap="medium">
-                        <LPTokensToRemoveInputField
-                          lpTokenBalance={lpTokenBalance}
-                          lpSharesInput={lpSharesInputMulti}
-                          setLpSharesInput={setLpSharesInputMulti}
-                          symbolFull={symbolFull}
-                        />
-                        <FormField label="You will receive">
-                          <Box direction="row">
-                            <Box gap="small" fill>
-                              <TextInput
-                                disabled
-                                readOnly
-                                id="exitMultiReceive"
-                                placeholder={`0 ${symbol}`}
-                                icon={
-                                  <Box pad="xsmall" direction="row" align="center" gap="small">
-                                    <Image height="35" src={`/${staker.bwLogo}`} />
-                                    <Text>{symbol}</Text>
-                                  </Box>
-                                }
-                                style={{ textAlign: "right", padding: "20px 50px" }}
-                                value={tokenOutput}
-                              />
-                              <TextInput
-                                readOnly
-                                disabled
-                                id="exitMultiReceive"
-                                placeholder={`0 t${symbol}`}
-                                icon={
-                                  <Box pad="xsmall" direction="row" align="center" gap="small">
-                                    <Image height="35" src={`/${staker.bwTenderLogo}`} />
-                                    <Text>t{symbol}</Text>
-                                  </Box>
-                                }
-                                style={{ textAlign: "right", padding: "20px 50px" }}
-                                value={tenderOutput}
-                              />
-                            </Box>
-                          </Box>
-                        </FormField>
-                      </Box>
-                    </Form>
-                  </Box>
+                  <RemoveMulti
+                    protocolName={protocolName}
+                    symbolFull={symbolFull}
+                    lpTokenBalance={lpTokenBalance}
+                    symbol={symbol}
+                    staker={staker}
+                    setSelectedToken={setSelectedToken}
+                  />
                 </Tab>
                 <Tab
                   title={
@@ -222,85 +102,252 @@ const RemoveLiquidity: FC<Props> = ({ protocolName, symbol, lpTokenBalance }) =>
                     </Box>
                   }
                 >
-                  <Box pad={{ top: "medium", horizontal: "large" }} align="center">
-                    <Form style={{ width: "100%" }}>
-                      <Box gap="medium">
-                        <LPTokensToRemoveInputField
-                          lpTokenBalance={lpTokenBalance}
-                          lpSharesInput={lpSharesInputSingle}
-                          setLpSharesInput={setLpSharesInputSingle}
-                          symbolFull={symbolFull}
-                        />
-                        <Box>
-                          <FormField label="Select Token To Receive" controlId="selectTokenReceive">
-                            <Select
-                              value={
-                                <TextInput
-                                  disabled
-                                  readOnly
-                                  value={utils.formatEther(singleOut)}
-                                  placeholder={"0"}
-                                  type="number"
-                                  style={{ textAlign: "right", padding: "20px 50px", border: "none" }}
-                                  icon={
-                                    <Box pad="xsmall" direction="row" align="center" gap="small">
-                                      <Image
-                                        height="35"
-                                        src={selectedToken === symbol ? `/${staker.bwLogo}` : `/${staker.bwTenderLogo}`}
-                                      />
-                                      <Text>{selectedToken === symbol ? symbol : `t${symbol}`}</Text>
-                                    </Box>
-                                  }
-                                />
-                              }
-                              options={[
-                                <Box direction="row" gap="small" align="center">
-                                  <Image
-                                    height={30}
-                                    width={30}
-                                    src={selectedToken === symbol ? `/${staker.bwTenderLogo}` : `/${staker.bwLogo}`}
-                                    alt="token logo"
-                                  />
-                                  {selectedToken === symbol ? `t${symbol}` : symbol}
-                                </Box>,
-                              ]}
-                              onChange={() => setSelectedToken(selectedToken === symbol ? `t${symbol}` : symbol)}
-                            />
-                          </FormField>
-                          <Text textAlign="end">{`Price impact: ${withDecimals(
-                            (priceImpact * 100).toString(),
-                            2
-                          )} %`}</Text>
-                        </Box>
-                      </Box>
-                    </Form>
-                  </Box>
+                  <RemoveSingle
+                    protocolName={protocolName}
+                    symbolFull={symbolFull}
+                    lpTokenBalance={lpTokenBalance}
+                    selectedToken={selectedToken}
+                    symbol={symbol}
+                    staker={staker}
+                    setSelectedToken={setSelectedToken}
+                  />
                 </Tab>
               </Tabs>
             </CardBody>
-            <CardFooter align="center" justify="center" pad={{ vertical: "medium" }}>
-              <Box style={{ width: "100%" }} pad={{ horizontal: "large" }} justify="center" gap="small">
-                <Button
-                  primary
-                  onClick={handleRemoveLiquidity}
-                  disabled={
-                    !hasValue(lpSharesInputSingle || lpSharesInputMulti) ||
-                    isPendingTransaction(exitPoolSingleTx) ||
-                    isPendingTransaction(exitPoolTx)
-                  }
-                  label={
-                    isPendingTransaction(exitPoolSingleTx) || isPendingTransaction(exitPoolTx) ? (
-                      <LoadingButtonContent label="Removing Liquidity..." />
-                    ) : (
-                      "Remove Liquidity"
-                    )
-                  }
-                />
-              </Box>
-            </CardFooter>
+            <CardFooter align="center" justify="center" pad={{ vertical: "medium" }}></CardFooter>
           </Card>
         </Layer>
       )}
+    </Box>
+  );
+};
+
+const RemoveMulti: FC<{
+  protocolName: ProtocolName;
+  symbolFull: string;
+  lpTokenBalance: BigNumberish;
+  symbol: string;
+  staker: Staker;
+  setSelectedToken: (v: string) => void;
+}> = ({ lpTokenBalance, symbolFull, symbol, staker, protocolName }) => {
+  const { account } = useEthers();
+
+  const [lpSharesInputMulti, setLpSharesInputMulti] = useState("");
+  const [tokenOutput, setTokenOutput] = useState("");
+  const [tenderOutput, setTenderOutput] = useState("");
+
+  const isLpSharesApproved = useIsTokenApproved(
+    addresses[protocolName].lpToken,
+    account,
+    addresses[protocolName].tenderSwap,
+    lpSharesInputMulti
+  );
+  const { removeLiquidity, exitPoolTx } = useExitPool(
+    addresses[protocolName].lpToken,
+    protocolName,
+    account,
+    addresses[protocolName].tenderSwap,
+    symbol,
+    isLpSharesApproved
+  );
+
+  const [tenderOut, tokenOut] = useCalculateRemoveLiquidity(
+    addresses[protocolName].tenderSwap,
+    utils.parseEther(lpSharesInputMulti || "0")
+  );
+
+  useEffect(() => {
+    setTokenOutput(weiToEthWithDecimals(tokenOut, 6));
+    setTenderOutput(weiToEthWithDecimals(tenderOut, 6));
+  }, [tenderOut, tokenOut]);
+
+  useResetInputAfterTx(exitPoolTx, setLpSharesInputMulti);
+
+  const handleRemoveLiquidity = async (e: any) => {
+    e.preventDefault();
+    // NOTE: Pool cardinality is tenderToken/Token
+    await removeLiquidity(utils.parseEther(lpSharesInputMulti || "0"), tenderOut, tokenOut);
+  };
+
+  return (
+    <Box pad={{ top: "medium", horizontal: "large" }} align="center">
+      <Form style={{ width: "100%" }}>
+        <Box gap="medium">
+          <LPTokensToRemoveInputField
+            lpTokenBalance={lpTokenBalance}
+            lpSharesInput={lpSharesInputMulti}
+            setLpSharesInput={setLpSharesInputMulti}
+            symbolFull={symbolFull}
+          />
+          <FormField label="You will receive">
+            <Box direction="row">
+              <Box gap="small" fill>
+                <TextInput
+                  disabled
+                  readOnly
+                  id="exitMultiReceive"
+                  placeholder={`0 ${symbol}`}
+                  icon={
+                    <Box pad="xsmall" direction="row" align="center" gap="small">
+                      <Image height="35" src={`/${staker.bwLogo}`} />
+                      <Text>{symbol}</Text>
+                    </Box>
+                  }
+                  style={{ textAlign: "right", padding: "20px 50px" }}
+                  value={tokenOutput}
+                />
+                <TextInput
+                  readOnly
+                  disabled
+                  id="exitMultiReceive"
+                  placeholder={`0 t${symbol}`}
+                  icon={
+                    <Box pad="xsmall" direction="row" align="center" gap="small">
+                      <Image height="35" src={`/${staker.bwTenderLogo}`} />
+                      <Text>t{symbol}</Text>
+                    </Box>
+                  }
+                  style={{ textAlign: "right", padding: "20px 50px" }}
+                  value={tenderOutput}
+                />
+              </Box>
+            </Box>
+          </FormField>
+        </Box>
+      </Form>
+      <Box style={{ width: "100%" }} pad={{ horizontal: "large" }} justify="center" gap="small">
+        <Button
+          primary
+          onClick={handleRemoveLiquidity}
+          disabled={!hasValue(lpSharesInputMulti) || isPendingTransaction(exitPoolTx)}
+          label={
+            isPendingTransaction(exitPoolTx) ? (
+              <LoadingButtonContent label="Removing Liquidity..." />
+            ) : (
+              "Remove Liquidity"
+            )
+          }
+        />
+      </Box>
+    </Box>
+  );
+};
+
+const RemoveSingle: FC<{
+  protocolName: ProtocolName;
+  symbolFull: string;
+  lpTokenBalance: BigNumberish;
+  selectedToken: string;
+  symbol: string;
+  staker: Staker;
+  setSelectedToken: (v: string) => void;
+}> = ({ lpTokenBalance, symbolFull, protocolName, symbol, selectedToken, staker, setSelectedToken }) => {
+  const { account } = useEthers();
+
+  const [lpSharesInputSingle, setLpSharesInputSingle] = useState("");
+
+  const singleTokenOutAddress =
+    selectedToken === symbol ? addresses[protocolName].token : addresses[protocolName].tenderToken;
+
+  const singleOut = useCalculateRemoveLiquidityOneToken(
+    addresses[protocolName].tenderSwap,
+    utils.parseEther(lpSharesInputSingle || "0"),
+    singleTokenOutAddress
+  );
+
+  const isLpSharesApproved = useIsTokenApproved(
+    addresses[protocolName].lpToken,
+    account,
+    addresses[protocolName].tenderSwap,
+    lpSharesInputSingle
+  );
+
+  const { priceImpact } = useLiquidityPriceImpact(
+    addresses[protocolName].tenderSwap,
+    false,
+    selectedToken === symbol ? weiToEthWithDecimals(singleOut, 6) : "0",
+    selectedToken === symbol ? "0" : weiToEthWithDecimals(singleOut, 6)
+  );
+
+  const { removeLiquiditySingleOut, tx: exitPoolSingleTx } = useExitPoolSingle(
+    addresses[protocolName].lpToken,
+    protocolName,
+    account,
+    addresses[protocolName].tenderSwap,
+    symbol,
+    isLpSharesApproved
+  );
+  useResetInputAfterTx(exitPoolSingleTx, setLpSharesInputSingle);
+
+  const handleRemoveLiquidity = async (e: any) => {
+    e.preventDefault();
+    await removeLiquiditySingleOut(utils.parseEther(lpSharesInputSingle || "0"), singleTokenOutAddress, singleOut);
+  };
+
+  return (
+    <Box pad={{ top: "medium", horizontal: "large" }} align="center">
+      <Form style={{ width: "100%" }}>
+        <Box gap="medium">
+          <LPTokensToRemoveInputField
+            lpTokenBalance={lpTokenBalance}
+            lpSharesInput={lpSharesInputSingle}
+            setLpSharesInput={setLpSharesInputSingle}
+            symbolFull={symbolFull}
+          />
+          <Box>
+            <FormField label="Select Token To Receive" controlId="selectTokenReceive">
+              <Select
+                value={
+                  <TextInput
+                    disabled
+                    readOnly
+                    value={utils.formatEther(singleOut)}
+                    placeholder={"0"}
+                    type="number"
+                    style={{ textAlign: "right", padding: "20px 50px", border: "none" }}
+                    icon={
+                      <Box pad="xsmall" direction="row" align="center" gap="small">
+                        <Image
+                          height="35"
+                          src={selectedToken === symbol ? `/${staker.bwLogo}` : `/${staker.bwTenderLogo}`}
+                        />
+                        <Text>{selectedToken === symbol ? symbol : `t${symbol}`}</Text>
+                      </Box>
+                    }
+                  />
+                }
+                options={[
+                  <Box direction="row" gap="small" align="center">
+                    <Image
+                      height={30}
+                      width={30}
+                      src={selectedToken === symbol ? `/${staker.bwTenderLogo}` : `/${staker.bwLogo}`}
+                      alt="token logo"
+                    />
+                    {selectedToken === symbol ? `t${symbol}` : symbol}
+                  </Box>,
+                ]}
+                onChange={() => setSelectedToken(selectedToken === symbol ? `t${symbol}` : symbol)}
+              />
+            </FormField>
+            <Text textAlign="end">{`Price impact: ${withDecimals((priceImpact * 100).toString(), 2)} %`}</Text>
+          </Box>
+        </Box>
+      </Form>
+      <Box style={{ width: "100%" }} pad={{ horizontal: "large" }} justify="center" gap="small">
+        <Button
+          primary
+          onClick={handleRemoveLiquidity}
+          disabled={!hasValue(lpSharesInputSingle) || isPendingTransaction(exitPoolSingleTx)}
+          label={
+            isPendingTransaction(exitPoolSingleTx) ? (
+              <LoadingButtonContent label="Removing Liquidity..." />
+            ) : (
+              "Remove Liquidity"
+            )
+          }
+        />
+      </Box>
     </Box>
   );
 };

--- a/packages/app/src/utils/inputValidation.ts
+++ b/packages/app/src/utils/inputValidation.ts
@@ -3,9 +3,9 @@ import { useEffect, useState } from "react";
 
 type ValidateFunction = () => { message: string; status: "error" | "info" } | undefined;
 
-export const isPositive = (val: string): boolean =>
-  val !== "" && !utils.parseEther(val).isNegative() && !utils.parseEther(val).isZero();
-
+export const isPositive = (val: string): boolean => {
+  return hasValue(val) && !utils.parseEther(val).isNegative() && !utils.parseEther(val).isZero();
+};
 export const isLargerThanMax = (val: string, max: BigNumberish): boolean => utils.parseEther(val).gt(max);
 
 export const validateIsPositive =
@@ -18,7 +18,7 @@ export const validateIsLargerThanMax =
   () =>
     isLargerThanMax(val, max) ? { message: "Amount exceeds available balance", status: "error" } : undefined;
 
-export const hasValue = (val: BigNumberish) => val && val !== "0";
+export const hasValue = (val: BigNumberish): boolean => !!val && val !== "0";
 
 export const useBalanceValidation = (input: string, balance: BigNumberish, extraDep?: string) => {
   const [validationMessage, setValidationMessage] = useState<string>();

--- a/packages/app/src/utils/tenderSwapHooks.ts
+++ b/packages/app/src/utils/tenderSwapHooks.ts
@@ -7,6 +7,7 @@ import { weiToEthInFloat } from "./amountFormat";
 import { signERC2612PermitPatched } from "./signERC2612PermitPatch";
 import { ProtocolName } from "@tender/shared/src/data/stakers";
 import { hasPermit } from "./context";
+import { useIsTokenApproved } from "components/approve/useIsTokenApproved";
 
 const TenderSwapABI = new utils.Interface(abis.tenderSwap);
 
@@ -221,9 +222,18 @@ export const useExitPoolSingle = (
   owner: string | null | undefined,
   spender: string,
   symbol: string,
-  isLpSharesApproved: boolean
+  lpSharesInputSingle: string
 ) => {
   const swapContract = new Contract(addresses[protocolName].tenderSwap, TenderSwapABI) as TenderSwap;
+
+  const { account } = useEthers();
+
+  const isLpSharesApproved = useIsTokenApproved(
+    addresses[protocolName].lpToken,
+    account,
+    addresses[protocolName].tenderSwap,
+    lpSharesInputSingle
+  );
 
   const { state: removeLiquidityWithPermitTx, send: multicall } = useContractFunction(swapContract, "multicall", {
     transactionName: `exit t${symbol}/${symbol} Liquidity Pool`,
@@ -287,9 +297,17 @@ export const useExitPool = (
   owner: string | null | undefined,
   spender: string,
   symbol: string,
-  isLpSharesApproved: boolean
+  lpSharesInputMulti: string
 ) => {
   const swapContract = new Contract(addresses[protocolName].tenderSwap, TenderSwapABI) as TenderSwap;
+
+  const { account } = useEthers();
+  const isLpSharesApproved = useIsTokenApproved(
+    addresses[protocolName].lpToken,
+    account,
+    addresses[protocolName].tenderSwap,
+    lpSharesInputMulti
+  );
 
   const { state: removeLiquidityWithPermitTx, send: multicall } = useContractFunction(swapContract, "multicall", {
     transactionName: `exit t${symbol}/${symbol} Liquidity Pool`,

--- a/packages/app/src/utils/useLPTokenOut.ts
+++ b/packages/app/src/utils/useLPTokenOut.ts
@@ -24,11 +24,11 @@ export const useLPTokenOut = (protocolName: ProtocolName, tenderInput: string, t
   }, [suggestedSlippage]);
 
   useEffect(() => {
-    const tokenIn = utils.parseEther(tokenInput || "0");
-    const tenderIn = utils.parseEther(tenderInput || "0");
-    const sumIn = tokenIn.add(tenderIn);
-    const outMin = sumIn.sub(sumIn.mul(slippage * 100).div(10000));
-    setLPTokenMinOut(outMin);
+    const tokenIn = Number.parseFloat(tokenInput || "0");
+    const tenderIn = Number.parseFloat(tenderInput || "0");
+    const sumIn = tokenIn + tenderIn;
+    const outMin = sumIn - (sumIn * slippage) / 100;
+    setLPTokenMinOut(utils.parseEther(outMin.toString()) ?? constants.Zero);
   }, [slippage, tokenInput, tenderInput]);
 
   return {

--- a/packages/app/src/utils/useLPTokenOut.ts
+++ b/packages/app/src/utils/useLPTokenOut.ts
@@ -1,0 +1,40 @@
+import { addresses } from "@tender/contracts/src";
+import { useCalculateLpTokenAmount } from "./tenderSwapHooks";
+import { ProtocolName } from "@tender/shared/src/data/stakers";
+import { constants, utils } from "ethers";
+import { useEffect, useState } from "react";
+import { weiToEthInFloat } from "./amountFormat";
+
+export const useLPTokenOut = (protocolName: ProtocolName, tenderInput: string, tokenInput: string) => {
+  const defaultLPTokenOut = useCalculateLpTokenAmount(
+    addresses[protocolName].tenderSwap,
+    [utils.parseEther(tenderInput || "0"), utils.parseEther(tokenInput || "0")],
+    true
+  );
+  const [lpTokenMinOut, setLPTokenMinOut] = useState(defaultLPTokenOut);
+
+  const sumIn = utils.parseEther(tokenInput || "0").add(utils.parseEther(tenderInput || "0"));
+  const suggestedSlippage = defaultLPTokenOut.eq(constants.Zero)
+    ? 0
+    : Math.round(Math.abs((1 - weiToEthInFloat(sumIn) / weiToEthInFloat(defaultLPTokenOut)) * 100) * 100) / 100;
+  const [slippage, setSlippage] = useState(suggestedSlippage);
+
+  useEffect(() => {
+    setSlippage(suggestedSlippage);
+  }, [suggestedSlippage]);
+
+  useEffect(() => {
+    const tokenIn = utils.parseEther(tokenInput || "0");
+    const tenderIn = utils.parseEther(tenderInput || "0");
+    const sumIn = tokenIn.add(tenderIn);
+    const outMin = sumIn.sub(sumIn.mul(slippage * 100).div(10000));
+    setLPTokenMinOut(outMin);
+  }, [slippage, tokenInput, tenderInput]);
+
+  return {
+    lpTokenMinOut,
+    slippage,
+    setSlippage,
+    suggestedSlippage,
+  };
+};

--- a/packages/app/src/utils/useLastProcessUnstakes.ts
+++ b/packages/app/src/utils/useLastProcessUnstakes.ts
@@ -32,8 +32,6 @@ export const useLastProcessUnstakes = (protocolName: ProtocolName) => {
         return prev;
       }
     }, processUnstakesEvents.processUnstakesEvents[0]);
-
-    console.log(lastProcessUnstakesEvent);
   }
   return { lastProcessUnstakesEvent };
 };

--- a/packages/app/src/utils/useResetInputAfterTx.ts
+++ b/packages/app/src/utils/useResetInputAfterTx.ts
@@ -8,3 +8,11 @@ export const useResetInputAfterTx = (tx: TransactionStatus, resetInput: (resetIn
     }
   }, [tx.status]);
 };
+
+export const useCloseAfterTx = (tx: TransactionStatus, handleClose: () => void) => {
+  useEffect(() => {
+    if (tx.status === "Success") {
+      handleClose();
+    }
+  }, [tx.status]);
+};

--- a/packages/app/src/utils/useWarningOnTxFailure.ts
+++ b/packages/app/src/utils/useWarningOnTxFailure.ts
@@ -7,7 +7,7 @@ export const useWarningOnTxFailure = (tx: TransactionStatus) => {
 
   useEffect(() => {
     if (tx.status === "Exception" || tx.status === "Fail") {
-      setErrorMessage(`There was a problem creating the transaction.`);
+      setErrorMessage(`There was a problem preparing your transaction. This might happen due to low slippage.`);
       setErrorInfo(`${tx.errorMessage}`);
     }
   }, [tx.status]);

--- a/packages/app/src/utils/useWarningOnTxFailure.ts
+++ b/packages/app/src/utils/useWarningOnTxFailure.ts
@@ -7,7 +7,7 @@ export const useWarningOnTxFailure = (tx: TransactionStatus) => {
 
   useEffect(() => {
     if (tx.status === "Exception" || tx.status === "Fail") {
-      setErrorMessage(`There was a problem preparing your transaction. This might happen due to low slippage.`);
+      setErrorMessage(`There was a problem preparing your transaction.`);
       setErrorInfo(`${tx.errorMessage}`);
     }
   }, [tx.status]);

--- a/packages/app/src/utils/useWarningOnTxFailure.ts
+++ b/packages/app/src/utils/useWarningOnTxFailure.ts
@@ -1,0 +1,16 @@
+import { TransactionStatus } from "@usedapp/core";
+import { useEffect, useState } from "react";
+
+export const useWarningOnTxFailure = (tx: TransactionStatus) => {
+  const [errorMessage, setErrorMessage] = useState<string>();
+  const [errorInfo, setErrorInfo] = useState<string>();
+
+  useEffect(() => {
+    if (tx.status === "Exception" || tx.status === "Fail") {
+      setErrorMessage(`There was a problem creating the transaction.`);
+      setErrorInfo(`${tx.errorMessage}`);
+    }
+  }, [tx.status]);
+
+  return { errorMessage, errorInfo };
+};

--- a/packages/app/test/components/deposit/helpers.test.ts
+++ b/packages/app/test/components/deposit/helpers.test.ts
@@ -9,7 +9,7 @@ const DAY = 24 * HOUR;
 
 describe("audius unlock labels", () => {
   test("open audius lock should be Ready", () => {
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -24,7 +24,7 @@ describe("audius unlock labels", () => {
   });
 
   test("new audius lock should be 7 days", () => {
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -39,7 +39,7 @@ describe("audius unlock labels", () => {
   });
 
   test("25 hour old audius lock should be 5 days", () => {
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -56,7 +56,7 @@ describe("audius unlock labels", () => {
   });
 
   test("6 days old audius lock should be 1 day", () => {
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -73,7 +73,7 @@ describe("audius unlock labels", () => {
   });
 
   test("6 days and 1 hour old audius lock should be 23 hours", () => {
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -90,7 +90,7 @@ describe("audius unlock labels", () => {
   });
 
   test("6 days and 23 hours old audius lock should be 1 hours", () => {
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -107,7 +107,7 @@ describe("audius unlock labels", () => {
   });
 
   test("6 days 23 hours and 20 minutes old audius lock should be 40 minutes", () => {
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -124,7 +124,7 @@ describe("audius unlock labels", () => {
   });
 
   test("7 days old audius lock should be 1 minute", () => {
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -141,7 +141,7 @@ describe("audius unlock labels", () => {
   });
 
   test("7 days and 1 second old audius lock should be Ready", () => {
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -157,7 +157,7 @@ describe("audius unlock labels", () => {
     expect(label).toBe("Ready");
   });
   test("20 days old audius lock should be Ready", () => {
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -176,7 +176,7 @@ describe("audius unlock labels", () => {
 
 describe("livepeer unlock labels", () => {
   test("open livepeer lock should be Ready", () => {
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -191,7 +191,7 @@ describe("livepeer unlock labels", () => {
   });
 
   test("new livepeer lock should be 7 days", () => {
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -206,7 +206,7 @@ describe("livepeer unlock labels", () => {
   });
 
   test("25 hour old livepeer lock should be 5 days", () => {
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -223,7 +223,7 @@ describe("livepeer unlock labels", () => {
   });
 
   test("6 days old livepeer lock should be 1 day", () => {
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -240,7 +240,7 @@ describe("livepeer unlock labels", () => {
   });
 
   test("6 days and 1 hour old livepeer lock should be 23 hours", () => {
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -257,7 +257,7 @@ describe("livepeer unlock labels", () => {
   });
 
   test("6 days and 23 hours old livepeer lock should be 1 hours", () => {
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -274,7 +274,7 @@ describe("livepeer unlock labels", () => {
   });
 
   test("6 days 23 hours and 20 minutes old livepeer lock should be 40 minutes", () => {
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -290,7 +290,7 @@ describe("livepeer unlock labels", () => {
     expect(label).toBe("~ 40 minutes");
   });
   test("7 days old livepeer lock should be 1 minute", () => {
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -307,7 +307,7 @@ describe("livepeer unlock labels", () => {
   });
 
   test("7 days and 1 second old livepeer lock should be Ready", () => {
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -324,7 +324,7 @@ describe("livepeer unlock labels", () => {
   });
 
   test("20 days old livepeer lock should be Ready", () => {
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -343,7 +343,7 @@ describe("livepeer unlock labels", () => {
 
 describe("matic unlock labels", () => {
   test("open matic lock should be Ready", () => {
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -358,7 +358,7 @@ describe("matic unlock labels", () => {
   });
 
   test("new matic lock should be 2 days", () => {
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -373,7 +373,7 @@ describe("matic unlock labels", () => {
   });
 
   test("12 hour old matic lock should be 1 day", () => {
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -390,7 +390,7 @@ describe("matic unlock labels", () => {
   });
 
   test("1 day old matic lock should be 1 day", () => {
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -407,7 +407,7 @@ describe("matic unlock labels", () => {
   });
 
   test("1 day and 1 hour old matic lock should be 23 hours", () => {
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -424,7 +424,7 @@ describe("matic unlock labels", () => {
   });
 
   test("1 day and 23 hours old matic lock should be 1 hours", () => {
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -441,7 +441,7 @@ describe("matic unlock labels", () => {
   });
 
   test("1 days 23 hours and 20 minutes old matic lock should be 40 minutes", () => {
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -458,7 +458,7 @@ describe("matic unlock labels", () => {
   });
 
   test("2 days old matic lock should be 1 minute", () => {
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -475,7 +475,7 @@ describe("matic unlock labels", () => {
   });
 
   test("2 days and 1 second old matic lock should be Ready", () => {
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -492,7 +492,7 @@ describe("matic unlock labels", () => {
   });
 
   test("20 days old matic lock should be Ready", () => {
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -511,7 +511,7 @@ describe("matic unlock labels", () => {
 
 describe("graph unlock labels", () => {
   test("graph without loaded processUnstakeEvents should be Loading...", () => {
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -526,7 +526,7 @@ describe("graph unlock labels", () => {
   });
 
   test("open graph lock should be Ready", () => {
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -541,7 +541,7 @@ describe("graph unlock labels", () => {
   });
 
   test("new graph lock with same time processUnstake should be 56 days", () => {
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -563,7 +563,7 @@ describe("graph unlock labels", () => {
   });
 
   test("graph lock with new processUnstake should be 28 days", () => {
-    const lockTime = new Date();
+    const lockTime = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -573,7 +573,7 @@ describe("graph unlock labels", () => {
       open: false,
     };
 
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     now.setTime(now.getTime() + DAY);
     const processUnstakeEvents: ProcessUnstakesEvent = {
       from: "",
@@ -588,7 +588,7 @@ describe("graph unlock labels", () => {
   });
 
   test("2 day old graph lock with 1 day old processUnstakes should be 27 days", () => {
-    const lockTime = new Date();
+    const lockTime = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -598,7 +598,7 @@ describe("graph unlock labels", () => {
       open: false,
     };
 
-    const processUnstakesTime = new Date();
+    const processUnstakesTime = new Date("January 17, 2023 09:00:00");
     processUnstakesTime.setTime(processUnstakesTime.getTime() + DAY);
     const processUnstakeEvents: ProcessUnstakesEvent = {
       from: "",
@@ -607,7 +607,7 @@ describe("graph unlock labels", () => {
       amount: "100",
       timestamp: (processUnstakesTime.getTime() / 1000).toString(),
     };
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     now.setTime(now.getTime() + 2 * DAY);
 
     const label = getUnlockDateForProtocol("graph", lock, processUnstakeEvents, now);
@@ -616,7 +616,7 @@ describe("graph unlock labels", () => {
   });
 
   test("5 day old graph lock with 1 day old processUnstakes should be 27 days", () => {
-    const lockTime = new Date();
+    const lockTime = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -626,7 +626,7 @@ describe("graph unlock labels", () => {
       open: false,
     };
 
-    const processUnstakesTime = new Date();
+    const processUnstakesTime = new Date("January 17, 2023 08:26:00");
     processUnstakesTime.setTime(processUnstakesTime.getTime() + 4 * DAY);
     const processUnstakeEvents: ProcessUnstakesEvent = {
       from: "",
@@ -635,7 +635,7 @@ describe("graph unlock labels", () => {
       amount: "100",
       timestamp: (processUnstakesTime.getTime() / 1000).toString(),
     };
-    const now = new Date();
+    const now = new Date("January 17, 2023 08:26:00");
     now.setTime(now.getTime() + 5 * DAY);
 
     const label = getUnlockDateForProtocol("graph", lock, processUnstakeEvents, now);
@@ -644,7 +644,7 @@ describe("graph unlock labels", () => {
   });
 
   test("29 day old graph lock with 27 day old processUnstakes should be 1 day", () => {
-    const lockTime = new Date();
+    const lockTime = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -654,7 +654,7 @@ describe("graph unlock labels", () => {
       open: false,
     };
 
-    const processUnstakesTime = new Date();
+    const processUnstakesTime = new Date("January 17, 2023 09:00:00");
     processUnstakesTime.setTime(processUnstakesTime.getTime() + 2 * DAY);
     const processUnstakeEvents: ProcessUnstakesEvent = {
       from: "",
@@ -663,7 +663,7 @@ describe("graph unlock labels", () => {
       amount: "100",
       timestamp: (processUnstakesTime.getTime() / 1000).toString(),
     };
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     now.setTime(now.getTime() + 29 * DAY);
 
     const label = getUnlockDateForProtocol("graph", lock, processUnstakeEvents, now);
@@ -672,7 +672,7 @@ describe("graph unlock labels", () => {
   });
 
   test("29 day old graph lock with 27 day and 1 hour old processUnstakes should be 23 hours", () => {
-    const lockTime = new Date();
+    const lockTime = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -682,7 +682,7 @@ describe("graph unlock labels", () => {
       open: false,
     };
 
-    const processUnstakesTime = new Date();
+    const processUnstakesTime = new Date("January 17, 2023 09:00:00");
     processUnstakesTime.setTime(processUnstakesTime.getTime() + 2 * DAY);
     const processUnstakeEvents: ProcessUnstakesEvent = {
       from: "",
@@ -691,7 +691,7 @@ describe("graph unlock labels", () => {
       amount: "100",
       timestamp: (processUnstakesTime.getTime() / 1000).toString(),
     };
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     now.setTime(now.getTime() + 29 * DAY + 1 * HOUR);
 
     const label = getUnlockDateForProtocol("graph", lock, processUnstakeEvents, now);
@@ -700,7 +700,7 @@ describe("graph unlock labels", () => {
   });
 
   test("29 day old graph lock with 27 day and 23 hour old processUnstakes should be 1 hour", () => {
-    const lockTime = new Date();
+    const lockTime = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -710,7 +710,7 @@ describe("graph unlock labels", () => {
       open: false,
     };
 
-    const processUnstakesTime = new Date();
+    const processUnstakesTime = new Date("January 17, 2023 09:00:00");
     processUnstakesTime.setTime(processUnstakesTime.getTime() + 2 * DAY);
     const processUnstakeEvents: ProcessUnstakesEvent = {
       from: "",
@@ -719,7 +719,7 @@ describe("graph unlock labels", () => {
       amount: "100",
       timestamp: (processUnstakesTime.getTime() / 1000).toString(),
     };
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     now.setTime(now.getTime() + 29 * DAY + 23 * HOUR);
 
     const label = getUnlockDateForProtocol("graph", lock, processUnstakeEvents, now);
@@ -728,7 +728,7 @@ describe("graph unlock labels", () => {
   });
 
   test("29 day old graph lock with 27 day and 23 hour and 20 minutes old processUnstakes should be 40 minutes", () => {
-    const lockTime = new Date();
+    const lockTime = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -738,7 +738,7 @@ describe("graph unlock labels", () => {
       open: false,
     };
 
-    const processUnstakesTime = new Date();
+    const processUnstakesTime = new Date("January 17, 2023 09:00:00");
     processUnstakesTime.setTime(processUnstakesTime.getTime() + 2 * DAY);
     const processUnstakeEvents: ProcessUnstakesEvent = {
       from: "",
@@ -747,7 +747,7 @@ describe("graph unlock labels", () => {
       amount: "100",
       timestamp: (processUnstakesTime.getTime() / 1000).toString(),
     };
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     now.setTime(now.getTime() + 29 * DAY + 23 * HOUR + 20 * MINUTE);
 
     const label = getUnlockDateForProtocol("graph", lock, processUnstakeEvents, now);
@@ -756,7 +756,7 @@ describe("graph unlock labels", () => {
   });
 
   test("29 day old graph lock with 28 days old processUnstakes should be 1 minute", () => {
-    const lockTime = new Date();
+    const lockTime = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -766,7 +766,7 @@ describe("graph unlock labels", () => {
       open: false,
     };
 
-    const processUnstakesTime = new Date();
+    const processUnstakesTime = new Date("January 17, 2023 09:00:00");
     processUnstakesTime.setTime(processUnstakesTime.getTime() + 2 * DAY);
     const processUnstakeEvents: ProcessUnstakesEvent = {
       from: "",
@@ -775,7 +775,7 @@ describe("graph unlock labels", () => {
       amount: "100",
       timestamp: (processUnstakesTime.getTime() / 1000).toString(),
     };
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     now.setTime(now.getTime() + 30 * DAY);
 
     const label = getUnlockDateForProtocol("graph", lock, processUnstakeEvents, now);
@@ -784,7 +784,7 @@ describe("graph unlock labels", () => {
   });
 
   test("29 day old graph lock with 28 days and 1 second old processUnstakes should be Ready", () => {
-    const lockTime = new Date();
+    const lockTime = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -794,7 +794,7 @@ describe("graph unlock labels", () => {
       open: false,
     };
 
-    const processUnstakesTime = new Date();
+    const processUnstakesTime = new Date("January 17, 2023 09:00:00");
     processUnstakesTime.setTime(processUnstakesTime.getTime() + 2 * DAY);
     const processUnstakeEvents: ProcessUnstakesEvent = {
       from: "",
@@ -803,7 +803,7 @@ describe("graph unlock labels", () => {
       amount: "100",
       timestamp: (processUnstakesTime.getTime() / 1000).toString(),
     };
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     now.setTime(now.getTime() + 30 * DAY + SEC);
 
     const label = getUnlockDateForProtocol("graph", lock, processUnstakeEvents, now);
@@ -812,7 +812,7 @@ describe("graph unlock labels", () => {
   });
 
   test("41 day old graph lock with 40 days old processUnstakes should be Ready", () => {
-    const lockTime = new Date();
+    const lockTime = new Date("January 17, 2023 09:00:00");
     const lock: Lock = {
       tenderizer: "",
       unstakeLockID: "1",
@@ -822,7 +822,7 @@ describe("graph unlock labels", () => {
       open: false,
     };
 
-    const processUnstakesTime = new Date();
+    const processUnstakesTime = new Date("January 17, 2023 09:00:00");
     processUnstakesTime.setTime(processUnstakesTime.getTime() + DAY);
     const processUnstakeEvents: ProcessUnstakesEvent = {
       from: "",
@@ -831,7 +831,7 @@ describe("graph unlock labels", () => {
       amount: "100",
       timestamp: (processUnstakesTime.getTime() / 1000).toString(),
     };
-    const now = new Date();
+    const now = new Date("January 17, 2023 09:00:00");
     now.setTime(now.getTime() + 41 * DAY);
 
     const label = getUnlockDateForProtocol("graph", lock, processUnstakeEvents, now);


### PR DESCRIPTION
fixes #359 
- manually set slippage for add liquidity
- error handling for add liquidity, can fail due to low slippage threshold
- error handling for single asset remove liquidity, can silently fail due to not enough liquidity

~~Remove liquidity in separate PR.~~

<img width="660" alt="Screenshot 2023-01-17 at 16 25 10" src="https://user-images.githubusercontent.com/2270661/212939113-6f680d0c-95df-40a9-b95b-d43f9e7beaf3.png">
